### PR TITLE
35 give option to produce abi names instead of register numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,70 @@
 # RISC-V Disassembler
+
 A RISC-V disassembler that translates machine code into a Rust enum, with the main purpose of being used in [Symex](https://github.com/simlar-0/symex) symbolic execution engine.
+
 ## Supported / Planned Instruction Sets
+
 - [x] RV32I Base Integer Instruction Set
 - [ ] RV64I Base Integer Instruction Set
 - [ ] RV32E Base Integer Instruction Sets
 - [ ] RV64E Base Integer Instruction Sets
 - [ ] RV32C Compressed Extension
+
 ## Output Format (Example)
+
 ```Rust
 pub enum ParsedInstruction32 {
     add {
-        rd: Register,
-        rs1: Register,
-        rs2: Register,
+        rd: String,
+        rs1: String,
+        rs2: String,
     },
     addi {
-        rd: Register,
-        rs1: Register,
+        rd: String,
+        rs1: String,
         imm: i32,
     },
 }
 ```
-where:
-```Rust
-pub enum Register {
-    x0 = 0,
-    x1 = 1,
-    x2 = 2,
-    x3 = 3,
-    x4 = 4,
-    .
-    .
-    .
-    x31 = 31,
-}
-```
+
 ## Example Usage
+
 ```Rust
-use risc_v_disassembler::{parse, ParsedInstruction32, Register};
+ use risc_v_disassembler::{
+     parse,
+     ParsedInstruction32,
+     parsed_instructions::*
+ };
 
-let bytes = [0x93, 0x00, 0x51, 0x00];
-let parsed_instruction = parse(&bytes).unwrap();
+ let bytes = [0x93, 0x00, 0x51, 0x00];
+ let is_big_endian = false;
+ let use_abi_register_names = false;
+ let parsed_instruction = parse(&bytes, is_big_endian, use_abi_register_names).unwrap();
 
-assert_eq!(parsed_instruction, ParsedInstruction32::addi {
-    rd: Register::x1,
-    rs1: Register::x2,
-    imm: 5
-});
+ assert_eq!(parsed_instruction, ParsedInstruction32::addi (addi {
+     rd: "x1".to_string(),
+     rs1: "x2".to_string(),
+     imm: 5
+ }));
+```
+
+ Or using ABI register names:
+
+```Rust
+ use risc_v_disassembler::{
+     parse,
+     ParsedInstruction32,
+     parsed_instructions::*
+ };
+
+ let bytes = [0x93, 0x00, 0x41, 0x00];
+ let is_big_endian = false;
+ let use_abi_register_names = true;
+ let parsed_instruction = parse(&bytes, is_big_endian, use_abi_register_names).unwrap();
+
+ assert_eq!(parsed_instruction, ParsedInstruction32::addi (addi {
+    rd: "ra".to_string(),
+    rs1: "sp".to_string(),
+    imm: 4
+ }));
 ```

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ pub enum ParsedInstruction32 {
  let parsed_instruction = parse(&bytes, is_big_endian, use_abi_register_names).unwrap();
 
  assert_eq!(parsed_instruction, ParsedInstruction32::addi (addi {
-     rd: "x1".to_string(),
-     rs1: "x2".to_string(),
+     rd: "x1",
+     rs1: "x2",
      imm: 5
  }));
 ```
@@ -63,8 +63,8 @@ pub enum ParsedInstruction32 {
  let parsed_instruction = parse(&bytes, is_big_endian, use_abi_register_names).unwrap();
 
  assert_eq!(parsed_instruction, ParsedInstruction32::addi (addi {
-    rd: "ra".to_string(),
-    rs1: "sp".to_string(),
+    rd: "ra",
+    rs1: "sp",
     imm: 4
  }));
 ```

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -1,8 +1,8 @@
 pub mod parsed_instructions;
 
-use std::fmt;
-use crate::DisassemblerError;
+use crate::{DisassemblerError, Register};
 use parsed_instructions::*;
+use std::fmt;
 
 pub type Instruction32 = u32;
 pub(crate) enum DecodedInstruction32 {
@@ -43,52 +43,52 @@ pub(crate) enum DecodedInstruction32 {
     JType {
         opcode: u8,
         rd: u8,
-        imm: i32
+        imm: i32,
     },
 }
 
 #[derive(Debug, PartialEq)]
 #[allow(non_camel_case_types)]
 pub enum ParsedInstruction32 {
-    add (add),
-    sub (sub),
-    xor (xor),
-    or (or),
-    and (and),
-    sll (sll),
-    srl (srl),
-    sra (sra),
-    slt (slt),
-    sltu (sltu),
-    addi (addi),
-    xori (xori),
-    ori (ori),
-    andi (andi),
-    slli (slli),
-    srli (srli),
-    srai (srai),
-    slti (slti),
-    sltiu (sltiu),
-    lb (lb),
-    lh (lh),
-    lw (lw),
-    lbu (lbu),
-    lhu (lhu),
-    sb (sb),
-    sh (sh),
-    sw (sw),
-    beq (beq),
-    bne (bne),
-    blt (blt),
-    bge (bge),
-    bltu (bltu),
-    bgeu (bgeu),
-    jal (jal),
-    jalr (jalr),
-    lui (lui),
-    auipc (auipc),
-    ecall (ecall),
-    ebreak (ebreak),
+    add(add),
+    sub(sub),
+    xor(xor),
+    or(or),
+    and(and),
+    sll(sll),
+    srl(srl),
+    sra(sra),
+    slt(slt),
+    sltu(sltu),
+    addi(addi),
+    xori(xori),
+    ori(ori),
+    andi(andi),
+    slli(slli),
+    srli(srli),
+    srai(srai),
+    slti(slti),
+    sltiu(sltiu),
+    lb(lb),
+    lh(lh),
+    lw(lw),
+    lbu(lbu),
+    lhu(lhu),
+    sb(sb),
+    sh(sh),
+    sw(sw),
+    beq(beq),
+    bne(bne),
+    blt(blt),
+    bge(bge),
+    bltu(bltu),
+    bgeu(bgeu),
+    jal(jal),
+    jalr(jalr),
+    lui(lui),
+    auipc(auipc),
+    ecall(ecall),
+    ebreak(ebreak),
 }
 
 pub(crate) trait DecodeInstruction32 {
@@ -96,80 +96,78 @@ pub(crate) trait DecodeInstruction32 {
 }
 
 pub(crate) trait ParseInstruction32 {
-    fn parse_instruction32(&self) -> Result<ParsedInstruction32, DisassemblerError>;
+    fn parse_instruction32<T: Register>(&self) -> Result<ParsedInstruction32, DisassemblerError>;
 }
 
 impl fmt::Display for ParsedInstruction32 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ParsedInstruction32::add (inner) => inner.fmt(f),
-            ParsedInstruction32::sub (inner) => inner.fmt(f),
-            ParsedInstruction32::xor (inner) => inner.fmt(f),
-            ParsedInstruction32::or (inner) => inner.fmt(f),
-            ParsedInstruction32::and (inner) => inner.fmt(f),
-            ParsedInstruction32::sll (inner) => inner.fmt(f),
-            ParsedInstruction32::srl (inner) => inner.fmt(f),
-            ParsedInstruction32::sra (inner) => inner.fmt(f),
-            ParsedInstruction32::slt (inner) => inner.fmt(f),
-            ParsedInstruction32::sltu (inner) => inner.fmt(f),
-            ParsedInstruction32::addi (inner) => inner.fmt(f),
-            ParsedInstruction32::xori (inner) => inner.fmt(f),
-            ParsedInstruction32::ori (inner) => inner.fmt(f),
-            ParsedInstruction32::andi (inner) => inner.fmt(f),
-            ParsedInstruction32::slli (inner) => inner.fmt(f),
-            ParsedInstruction32::srli (inner) => inner.fmt(f),
-            ParsedInstruction32::srai (inner) => inner.fmt(f),
-            ParsedInstruction32::slti (inner) => inner.fmt(f),
-            ParsedInstruction32::sltiu (inner) => inner.fmt(f),
-            ParsedInstruction32::lb (inner) => inner.fmt(f),
-            ParsedInstruction32::lh (inner) => inner.fmt(f),
-            ParsedInstruction32::lw (inner) => inner.fmt(f),
-            ParsedInstruction32::lbu (inner) => inner.fmt(f),
-            ParsedInstruction32::lhu (inner) => inner.fmt(f),
-            ParsedInstruction32::sb (inner) => inner.fmt(f),
-            ParsedInstruction32::sh (inner) => inner.fmt(f),
-            ParsedInstruction32::sw (inner) => inner.fmt(f),
-            ParsedInstruction32::beq (inner) => inner.fmt(f),
-            ParsedInstruction32::bne (inner) => inner.fmt(f),
-            ParsedInstruction32::blt (inner) => inner.fmt(f),
-            ParsedInstruction32::bge (inner) => inner.fmt(f),
-            ParsedInstruction32::bltu (inner) => inner.fmt(f),
-            ParsedInstruction32::bgeu (inner) => inner.fmt(f),
-            ParsedInstruction32::jal (inner) => inner.fmt(f),
-            ParsedInstruction32::jalr (inner) => inner.fmt(f),
-            ParsedInstruction32::lui (inner) => inner.fmt(f),
-            ParsedInstruction32::auipc (inner) => inner.fmt(f),
-            ParsedInstruction32::ecall (inner) => inner.fmt(f),
-            ParsedInstruction32::ebreak (inner) => inner.fmt(f),
+            ParsedInstruction32::add(inner) => inner.fmt(f),
+            ParsedInstruction32::sub(inner) => inner.fmt(f),
+            ParsedInstruction32::xor(inner) => inner.fmt(f),
+            ParsedInstruction32::or(inner) => inner.fmt(f),
+            ParsedInstruction32::and(inner) => inner.fmt(f),
+            ParsedInstruction32::sll(inner) => inner.fmt(f),
+            ParsedInstruction32::srl(inner) => inner.fmt(f),
+            ParsedInstruction32::sra(inner) => inner.fmt(f),
+            ParsedInstruction32::slt(inner) => inner.fmt(f),
+            ParsedInstruction32::sltu(inner) => inner.fmt(f),
+            ParsedInstruction32::addi(inner) => inner.fmt(f),
+            ParsedInstruction32::xori(inner) => inner.fmt(f),
+            ParsedInstruction32::ori(inner) => inner.fmt(f),
+            ParsedInstruction32::andi(inner) => inner.fmt(f),
+            ParsedInstruction32::slli(inner) => inner.fmt(f),
+            ParsedInstruction32::srli(inner) => inner.fmt(f),
+            ParsedInstruction32::srai(inner) => inner.fmt(f),
+            ParsedInstruction32::slti(inner) => inner.fmt(f),
+            ParsedInstruction32::sltiu(inner) => inner.fmt(f),
+            ParsedInstruction32::lb(inner) => inner.fmt(f),
+            ParsedInstruction32::lh(inner) => inner.fmt(f),
+            ParsedInstruction32::lw(inner) => inner.fmt(f),
+            ParsedInstruction32::lbu(inner) => inner.fmt(f),
+            ParsedInstruction32::lhu(inner) => inner.fmt(f),
+            ParsedInstruction32::sb(inner) => inner.fmt(f),
+            ParsedInstruction32::sh(inner) => inner.fmt(f),
+            ParsedInstruction32::sw(inner) => inner.fmt(f),
+            ParsedInstruction32::beq(inner) => inner.fmt(f),
+            ParsedInstruction32::bne(inner) => inner.fmt(f),
+            ParsedInstruction32::blt(inner) => inner.fmt(f),
+            ParsedInstruction32::bge(inner) => inner.fmt(f),
+            ParsedInstruction32::bltu(inner) => inner.fmt(f),
+            ParsedInstruction32::bgeu(inner) => inner.fmt(f),
+            ParsedInstruction32::jal(inner) => inner.fmt(f),
+            ParsedInstruction32::jalr(inner) => inner.fmt(f),
+            ParsedInstruction32::lui(inner) => inner.fmt(f),
+            ParsedInstruction32::auipc(inner) => inner.fmt(f),
+            ParsedInstruction32::ecall(inner) => inner.fmt(f),
+            ParsedInstruction32::ebreak(inner) => inner.fmt(f),
         }
     }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::ParsedInstruction32;
     use crate::instructions::parsed_instructions::*;
-    use crate::registers::Register;
+    use crate::ParsedInstruction32;
 
-    
     #[test]
     fn test_instruction_printing() {
-        let parsed_add: ParsedInstruction32 = ParsedInstruction32::add (add {
-            rd: Register::x1,
-            rs1: Register::x2,
-            rs2: Register::x3,
+        let parsed_add: ParsedInstruction32 = ParsedInstruction32::add(add {
+            rd: "x1".to_string(),
+            rs1: "x2".to_string(),
+            rs2: "x3".to_string(),
         });
         assert_eq!(format!("{}", parsed_add), "add x1, x2, x3");
 
-        let parsed_addi: ParsedInstruction32 = ParsedInstruction32::addi (addi {
-            rd: Register::x1,
-            rs1: Register::x31,
+        let parsed_addi: ParsedInstruction32 = ParsedInstruction32::addi(addi {
+            rd: "x1".to_string(),
+            rs1: "x31".to_string(),
             imm: -5,
         });
         assert_eq!(format!("{}", parsed_addi), "addi x1, x31, -5");
 
-        let parsed_jal: ParsedInstruction32 = ParsedInstruction32::jal (jal {
-            rd: Register::x1,
+        let parsed_jal: ParsedInstruction32 = ParsedInstruction32::jal(jal {
+            rd: "x1".to_string(),
             imm: 5,
         });
         assert_eq!(format!("{}", parsed_jal), "jal x1, 5");

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -153,23 +153,20 @@ mod test {
     #[test]
     fn test_instruction_printing() {
         let parsed_add: ParsedInstruction32 = ParsedInstruction32::add(add {
-            rd: "x1".to_string(),
-            rs1: "x2".to_string(),
-            rs2: "x3".to_string(),
+            rd: "x1",
+            rs1: "x2",
+            rs2: "x3",
         });
         assert_eq!(format!("{}", parsed_add), "add x1, x2, x3");
 
         let parsed_addi: ParsedInstruction32 = ParsedInstruction32::addi(addi {
-            rd: "x1".to_string(),
-            rs1: "x31".to_string(),
+            rd: "x1",
+            rs1: "x31",
             imm: -5,
         });
         assert_eq!(format!("{}", parsed_addi), "addi x1, x31, -5");
 
-        let parsed_jal: ParsedInstruction32 = ParsedInstruction32::jal(jal {
-            rd: "x1".to_string(),
-            imm: 5,
-        });
+        let parsed_jal: ParsedInstruction32 = ParsedInstruction32::jal(jal { rd: "x1", imm: 5 });
         assert_eq!(format!("{}", parsed_jal), "jal x1, 5");
 
         let parsed_ecall: ParsedInstruction32 = ParsedInstruction32::ecall(ecall {});

--- a/src/instructions/parsed_instructions.rs
+++ b/src/instructions/parsed_instructions.rs
@@ -4,257 +4,257 @@ use std::fmt;
 
 #[derive(Debug, PartialEq)]
 pub struct add {
-    pub rd: String,
-    pub rs1: String,
-    pub rs2: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
+    pub rs2: &'static str,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct sub {
-    pub rd: String,
-    pub rs1: String,
-    pub rs2: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
+    pub rs2: &'static str,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct xor {
-    pub rd: String,
-    pub rs1: String,
-    pub rs2: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
+    pub rs2: &'static str,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct or {
-    pub rd: String,
-    pub rs1: String,
-    pub rs2: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
+    pub rs2: &'static str,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct and {
-    pub rd: String,
-    pub rs1: String,
-    pub rs2: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
+    pub rs2: &'static str,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct sll {
-    pub rd: String,
-    pub rs1: String,
-    pub rs2: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
+    pub rs2: &'static str,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct srl {
-    pub rd: String,
-    pub rs1: String,
-    pub rs2: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
+    pub rs2: &'static str,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct sra {
-    pub rd: String,
-    pub rs1: String,
-    pub rs2: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
+    pub rs2: &'static str,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct slt {
-    pub rd: String,
-    pub rs1: String,
-    pub rs2: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
+    pub rs2: &'static str,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct sltu {
-    pub rd: String,
-    pub rs1: String,
-    pub rs2: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
+    pub rs2: &'static str,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct addi {
-    pub rd: String,
-    pub rs1: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct xori {
-    pub rd: String,
-    pub rs1: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct ori {
-    pub rd: String,
-    pub rs1: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct andi {
-    pub rd: String,
-    pub rs1: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct slli {
-    pub rd: String,
-    pub rs1: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
     pub shamt: u8,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct srli {
-    pub rd: String,
-    pub rs1: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
     pub shamt: u8,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct srai {
-    pub rd: String,
-    pub rs1: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
     pub shamt: u8,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct slti {
-    pub rd: String,
-    pub rs1: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct sltiu {
-    pub rd: String,
-    pub rs1: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct lb {
-    pub rd: String,
-    pub rs1: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct lh {
-    pub rd: String,
-    pub rs1: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct lw {
-    pub rd: String,
-    pub rs1: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct lbu {
-    pub rd: String,
-    pub rs1: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct lhu {
-    pub rd: String,
-    pub rs1: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct sb {
-    pub rs1: String,
-    pub rs2: String,
+    pub rs1: &'static str,
+    pub rs2: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct sh {
-    pub rs1: String,
-    pub rs2: String,
+    pub rs1: &'static str,
+    pub rs2: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct sw {
-    pub rs1: String,
-    pub rs2: String,
+    pub rs1: &'static str,
+    pub rs2: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct beq {
-    pub rs1: String,
-    pub rs2: String,
+    pub rs1: &'static str,
+    pub rs2: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct bne {
-    pub rs1: String,
-    pub rs2: String,
+    pub rs1: &'static str,
+    pub rs2: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct blt {
-    pub rs1: String,
-    pub rs2: String,
+    pub rs1: &'static str,
+    pub rs2: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct bge {
-    pub rs1: String,
-    pub rs2: String,
+    pub rs1: &'static str,
+    pub rs2: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct bltu {
-    pub rs1: String,
-    pub rs2: String,
+    pub rs1: &'static str,
+    pub rs2: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct bgeu {
-    pub rs1: String,
-    pub rs2: String,
+    pub rs1: &'static str,
+    pub rs2: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct jal {
-    pub rd: String,
+    pub rd: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct jalr {
-    pub rd: String,
-    pub rs1: String,
+    pub rd: &'static str,
+    pub rs1: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct lui {
-    pub rd: String,
+    pub rd: &'static str,
     pub imm: i32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct auipc {
-    pub rd: String,
+    pub rd: &'static str,
     pub imm: i32,
 }
 
@@ -497,4 +497,3 @@ impl fmt::Display for ebreak {
         write!(f, "ebreak")
     }
 }
-

--- a/src/instructions/parsed_instructions.rs
+++ b/src/instructions/parsed_instructions.rs
@@ -1,270 +1,268 @@
 #![allow(non_camel_case_types)]
 
 use std::fmt;
-use crate::registers::Register;
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct add {
-    pub rd: Register,
-    pub rs1: Register,
-    pub rs2: Register,
+    pub rd: String,
+    pub rs1: String,
+    pub rs2: String,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct sub {
-    pub rd: Register,
-    pub rs1: Register,
-    pub rs2: Register,
+    pub rd: String,
+    pub rs1: String,
+    pub rs2: String,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct xor {
-    pub rd: Register,
-    pub rs1: Register,
-    pub rs2: Register,
+    pub rd: String,
+    pub rs1: String,
+    pub rs2: String,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct or {
-    pub rd: Register,
-    pub rs1: Register,
-    pub rs2: Register,
+    pub rd: String,
+    pub rs1: String,
+    pub rs2: String,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct and {
-    pub rd: Register,
-    pub rs1: Register,
-    pub rs2: Register,
+    pub rd: String,
+    pub rs1: String,
+    pub rs2: String,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct sll {
-    pub rd: Register,
-    pub rs1: Register,
-    pub rs2: Register,
+    pub rd: String,
+    pub rs1: String,
+    pub rs2: String,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct srl {
-    pub rd: Register,
-    pub rs1: Register,
-    pub rs2: Register,
+    pub rd: String,
+    pub rs1: String,
+    pub rs2: String,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct sra {
-    pub rd: Register,
-    pub rs1: Register,
-    pub rs2: Register,
+    pub rd: String,
+    pub rs1: String,
+    pub rs2: String,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct slt {
-    pub rd: Register,
-    pub rs1: Register,
-    pub rs2: Register,
+    pub rd: String,
+    pub rs1: String,
+    pub rs2: String,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct sltu {
-    pub rd: Register,
-    pub rs1: Register,
-    pub rs2: Register,
+    pub rd: String,
+    pub rs1: String,
+    pub rs2: String,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct addi {
-    pub rd: Register,
-    pub rs1: Register,
+    pub rd: String,
+    pub rs1: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct xori {
-    pub rd: Register,
-    pub rs1: Register,
+    pub rd: String,
+    pub rs1: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct ori {
-    pub rd: Register,
-    pub rs1: Register,
+    pub rd: String,
+    pub rs1: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct andi {
-    pub rd: Register,
-    pub rs1: Register,
+    pub rd: String,
+    pub rs1: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct slli {
-    pub rd: Register,
-    pub rs1: Register,
+    pub rd: String,
+    pub rs1: String,
     pub shamt: u8,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct srli {
-    pub rd: Register,
-    pub rs1: Register,
+    pub rd: String,
+    pub rs1: String,
     pub shamt: u8,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct srai {
-    pub rd: Register,
-    pub rs1: Register,
+    pub rd: String,
+    pub rs1: String,
     pub shamt: u8,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct slti {
-    pub rd: Register,
-    pub rs1: Register,
+    pub rd: String,
+    pub rs1: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct sltiu {
-    pub rd: Register,
-    pub rs1: Register,
+    pub rd: String,
+    pub rs1: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct lb {
-    pub rd: Register,
-    pub rs1: Register,
+    pub rd: String,
+    pub rs1: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct lh {
-    pub rd: Register,
-    pub rs1: Register,
+    pub rd: String,
+    pub rs1: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct lw {
-    pub rd: Register,
-    pub rs1: Register,
+    pub rd: String,
+    pub rs1: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct lbu {
-    pub rd: Register,
-    pub rs1: Register,
+    pub rd: String,
+    pub rs1: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct lhu {
-    pub rd: Register,
-    pub rs1: Register,
+    pub rd: String,
+    pub rs1: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct sb {
-    pub rs1: Register,
-    pub rs2: Register,
+    pub rs1: String,
+    pub rs2: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct sh {
-    pub rs1: Register,
-    pub rs2: Register,
+    pub rs1: String,
+    pub rs2: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct sw {
-    pub rs1: Register,
-    pub rs2: Register,
+    pub rs1: String,
+    pub rs2: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct beq {
-    pub rs1: Register,
-    pub rs2: Register,
+    pub rs1: String,
+    pub rs2: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct bne {
-    pub rs1: Register,
-    pub rs2: Register,
+    pub rs1: String,
+    pub rs2: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct blt {
-    pub rs1: Register,
-    pub rs2: Register,
+    pub rs1: String,
+    pub rs2: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct bge {
-    pub rs1: Register,
-    pub rs2: Register,
+    pub rs1: String,
+    pub rs2: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct bltu {
-    pub rs1: Register,
-    pub rs2: Register,
+    pub rs1: String,
+    pub rs2: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct bgeu {
-    pub rs1: Register,
-    pub rs2: Register,
+    pub rs1: String,
+    pub rs2: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct jal {
-    pub rd: Register,
+    pub rd: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct jalr {
-    pub rd: Register,
-    pub rs1: Register,
+    pub rd: String,
+    pub rs1: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct lui {
-    pub rd: Register,
+    pub rd: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct auipc {
-    pub rd: Register,
+    pub rd: String,
     pub imm: i32,
 }
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct ecall {}
 
-#[derive(Debug, PartialEq)] 
+#[derive(Debug, PartialEq)]
 pub struct ebreak {}
-
 
 impl fmt::Display for add {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -499,3 +497,4 @@ impl fmt::Display for ebreak {
         write!(f, "ebreak")
     }
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,8 @@
 //! let parsed_instruction = parse(&bytes, is_big_endian, use_abi_register_names).unwrap();
 //!
 //! assert_eq!(parsed_instruction, ParsedInstruction32::addi (addi {
-//!     rd: "x1".to_string(),
-//!     rs1: "x2".to_string(),
+//!     rd: "x1",
+//!     rs1: "x2",
 //!     imm: 5
 //! }));
 //! ```
@@ -51,8 +51,8 @@
 //! let parsed_instruction = parse(&bytes, is_big_endian, use_abi_register_names).unwrap();
 
 //! assert_eq!(parsed_instruction, ParsedInstruction32::addi (addi {
-//!    rd: "ra".to_string(),
-//!    rs1: "sp".to_string(),
+//!    rd: "ra",
+//!    rs1: "sp",
 //!    imm: 4
 //! }));
 //! ``` `

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 //!     ParsedInstruction32,
 //!     parsed_instructions::*
 //! };
-//! use risc_v_disassembler::Register;
 //!
 //! let bytes = [0x93, 0x00, 0x51, 0x00];
 //! let is_big_endian = false;
@@ -38,6 +37,25 @@
 //! }));
 //! ```
 //!
+//! Or using ABI register names:
+//! ```
+//! use risc_v_disassembler::{
+//!     parse,
+//!     ParsedInstruction32,
+//!     parsed_instructions::*
+//! };
+//!
+//! let bytes = [0x93, 0x00, 0x41, 0x00];
+//! let is_big_endian = false;
+//! let use_abi_register_names = true;
+//! let parsed_instruction = parse(&bytes, is_big_endian, use_abi_register_names).unwrap();
+
+//! assert_eq!(parsed_instruction, ParsedInstruction32::addi (addi {
+//!    rd: "ra".to_string(),
+//!    rs1: "sp".to_string(),
+//!    imm: 4
+//! }));
+//! ``` `
 
 mod decoder;
 mod instructions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,23 +1,23 @@
 //! A simple disassembler for the RISC-V instruction set architecture.
 //! It currently only supports 32 bit RV32I instructions.
-//! 
+//!
 //! ### Supported Instruction Sets
 //!  - RV32I
-//! 
+//!
 //! Parses a byte array slice into a `ParsedInstruction32` enum representing a RISC-V instruction.
-//! 
+//!
 //! ### Arguments
-//! 
+//!
 //! * `bytes` - A slice of bytes representing the encoded instruction to be parsed.
 //! * `is_big_endian` - A boolean indicating whether the bytes are in big endian format.
-//! 
+//!
 //! ### Returns
-//! 
+//!
 //! * `Ok(ParsedInstruction32)` - If the parsing is successful, returns the parsed instruction.
 //! * `Err(DisassemblerError)` - If the parsing fails, returns an error indicating the reason for failure.
-//! 
+//!
 //! ### Example
-//! 
+//!
 //! ```
 //! use risc_v_disassembler::{
 //!     parse,
@@ -25,74 +25,90 @@
 //!     parsed_instructions::*
 //! };
 //! use risc_v_disassembler::Register;
-//! 
+//!
 //! let bytes = [0x93, 0x00, 0x51, 0x00];
 //! let is_big_endian = false;
-//! let parsed_instruction = parse(&bytes, is_big_endian).unwrap();
-//! 
+//! let use_abi_register_names = false;
+//! let parsed_instruction = parse(&bytes, is_big_endian, use_abi_register_names).unwrap();
+//!
 //! assert_eq!(parsed_instruction, ParsedInstruction32::addi (addi {
-//!     rd: Register::x1,
-//!     rs1: Register::x2,
+//!     rd: "x1".to_string(),
+//!     rs1: "x2".to_string(),
 //!     imm: 5
 //! }));
 //! ```
-//! 
+//!
 
-mod registers;
+mod decoder;
 mod instructions;
 mod macros;
-mod decoder;
 mod parser;
+mod registers;
 
-pub use instructions::{
-    ParsedInstruction32,
-    parsed_instructions,
-};
+pub use instructions::{parsed_instructions, ParsedInstruction32};
+use instructions::{DecodeInstruction32, Instruction32, ParseInstruction32};
 pub use registers::Register;
-use instructions::{Instruction32, ParseInstruction32, DecodeInstruction32};
 use thiserror::Error;
 
-pub fn parse(bytes : &[u8], is_big_endian: bool) -> Result<ParsedInstruction32, DisassemblerError> {
+pub fn parse(
+    bytes: &[u8],
+    is_big_endian: bool,
+    use_abi_register_names: bool,
+) -> Result<ParsedInstruction32, DisassemblerError> {
     if bytes.len() != 4 {
         return Err(DisassemblerError::UnsupportedInstructionLength(bytes.len()));
     }
-    
+
     let instruction = if is_big_endian {
         Instruction32::from_be_bytes(bytes.try_into().unwrap())
     } else {
         Instruction32::from_le_bytes(bytes.try_into().unwrap())
     };
 
-    let parsed_instruction = instruction
-        .decode_instruction32()?
-        .parse_instruction32()?;
+    let decoded_instruction = instruction.decode_instruction32()?;
+
+    let parsed_instruction = if use_abi_register_names {
+        decoded_instruction.parse_instruction32::<registers::ABIRegister>()?
+    } else {
+        decoded_instruction.parse_instruction32::<registers::NumberedRegister>()?
+    };
+
     Ok(parsed_instruction)
 }
 
 #[derive(Debug, Error, PartialEq)]
 pub enum DisassemblerError {
-    #[error("Unsupported instruction length: {0}. The length of the instruction is not supported.")]
+    #[error(
+        "Unsupported instruction length: {0}. The length of the instruction is not supported."
+    )]
     UnsupportedInstructionLength(usize),
 
-    #[error("Invalid funct3 field with value {0:b}. The value is not valid for the given instruction.")]
+    #[error(
+        "Invalid funct3 field with value {0:b}. The value is not valid for the given instruction."
+    )]
     InvalidFunct3(u8),
 
-    #[error("Invalid funct7 field with value {0:b}. The value is not valid for the given instruction.")]
+    #[error(
+        "Invalid funct7 field with value {0:b}. The value is not valid for the given instruction."
+    )]
     InvalidFunct7(u8),
 
-    #[error("Invalid opcode field with value {0:b}. The value is not valid for the given instruction.")]
+    #[error(
+        "Invalid opcode field with value {0:b}. The value is not valid for the given instruction."
+    )]
     InvalidOpcode(u8),
-    
-    #[error("Invalid immediate: {0:b}. The immediate value is not valid for the given instruction.")]
+
+    #[error(
+        "Invalid immediate: {0:b}. The immediate value is not valid for the given instruction."
+    )]
     InvalidImmediate(i32),
 
     #[error("Invalid register: {0:?}. The register index is out of bounds.")]
     InvalidRegister(u8),
-    
+
     #[error("Bit extraction error: {0}.")]
     BitExtractionError(&'static str),
 
     #[error("Bit extension error: {0}.")]
     BitExtensionError(&'static str),
 }
-

--- a/src/parser/btype.rs
+++ b/src/parser/btype.rs
@@ -1,69 +1,102 @@
-use crate::instructions::{
-    ParsedInstruction32,
-    parsed_instructions::*
-};
+use crate::instructions::{parsed_instructions::*, ParsedInstruction32};
 use crate::registers::Register;
 use crate::DisassemblerError;
 
-pub(crate) fn parse_btype32(_opcode: &u8, imm: &i32, funct3: &u8, rs1: &u8, rs2: &u8) -> Result<ParsedInstruction32, DisassemblerError> {
-    let rs1 = Register::try_from(*rs1)?;
-    let rs2 = Register::try_from(*rs2)?;
-    
+pub(crate) fn parse_btype32<T: Register>(
+    _opcode: &u8,
+    imm: &i32,
+    funct3: &u8,
+    rs1: &u8,
+    rs2: &u8,
+) -> Result<ParsedInstruction32, DisassemblerError> {
+    let rs1 = T::from_u8(*rs1)?.as_string();
+    let rs2 = T::from_u8(*rs2)?.as_string();
+
     match funct3 {
-        0b000 => Ok(ParsedInstruction32::beq (beq { rs1, rs2, imm: *imm })),
-        0b001 => Ok(ParsedInstruction32::bne (bne { rs1, rs2, imm: *imm })),
-        0b100 => Ok(ParsedInstruction32::blt (blt { rs1, rs2, imm: *imm })),
-        0b101 => Ok(ParsedInstruction32::bge (bge { rs1, rs2, imm: *imm })),
-        0b110 => Ok(ParsedInstruction32::bltu (bltu { rs1, rs2, imm: *imm })),
-        0b111 => Ok(ParsedInstruction32::bgeu (bgeu { rs1, rs2, imm: *imm })),
+        0b000 => Ok(ParsedInstruction32::beq(beq {
+            rs1,
+            rs2,
+            imm: *imm,
+        })),
+        0b001 => Ok(ParsedInstruction32::bne(bne {
+            rs1,
+            rs2,
+            imm: *imm,
+        })),
+        0b100 => Ok(ParsedInstruction32::blt(blt {
+            rs1,
+            rs2,
+            imm: *imm,
+        })),
+        0b101 => Ok(ParsedInstruction32::bge(bge {
+            rs1,
+            rs2,
+            imm: *imm,
+        })),
+        0b110 => Ok(ParsedInstruction32::bltu(bltu {
+            rs1,
+            rs2,
+            imm: *imm,
+        })),
+        0b111 => Ok(ParsedInstruction32::bgeu(bgeu {
+            rs1,
+            rs2,
+            imm: *imm,
+        })),
         _ => Err(DisassemblerError::InvalidFunct3(*funct3)),
     }
 }
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::instructions::ParsedInstruction32;
+    use crate::{instructions::ParsedInstruction32, registers::NumberedRegister};
 
     #[test]
     fn test_parse_btype32_beq() {
-        let result = parse_btype32(&0b1100011, &1, &0b000, &0b00010, &0b00011).unwrap();
-        assert!(matches!(result, ParsedInstruction32::beq {..}));
+        let result =
+            parse_btype32::<NumberedRegister>(&0b1100011, &1, &0b000, &0b00010, &0b00011).unwrap();
+        assert!(matches!(result, ParsedInstruction32::beq { .. }));
     }
 
     #[test]
     fn test_parse_btype32_bne() {
-        let result = parse_btype32(&0b1100011, &1, &0b001, &0b00010, &0b00011).unwrap();
-        assert!(matches!(result, ParsedInstruction32::bne {..}));
+        let result =
+            parse_btype32::<NumberedRegister>(&0b1100011, &1, &0b001, &0b00010, &0b00011).unwrap();
+        assert!(matches!(result, ParsedInstruction32::bne { .. }));
     }
 
     #[test]
     fn test_parse_btype32_invalid_funct3() {
-        let result = parse_btype32(&0b1100011, &1, &0b010, &0b00010, &0b00011);
+        let result = parse_btype32::<NumberedRegister>(&0b1100011, &1, &0b010, &0b00010, &0b00011);
         assert!(result.is_err());
         assert_eq!(result.err(), Some(DisassemblerError::InvalidFunct3(0b010)));
     }
 
     #[test]
     fn test_parse_btype32_blt() {
-        let result = parse_btype32(&0b1100011, &1, &0b100, &0b00010, &0b00011).unwrap();
-        assert!(matches!(result, ParsedInstruction32::blt {..}));
+        let result =
+            parse_btype32::<NumberedRegister>(&0b1100011, &1, &0b100, &0b00010, &0b00011).unwrap();
+        assert!(matches!(result, ParsedInstruction32::blt { .. }));
     }
 
     #[test]
     fn test_parse_btype32_bge() {
-        let result = parse_btype32(&0b1100011, &1, &0b101, &0b00010, &0b00011).unwrap();
-        assert!(matches!(result, ParsedInstruction32::bge {..}));
+        let result =
+            parse_btype32::<NumberedRegister>(&0b1100011, &1, &0b101, &0b00010, &0b00011).unwrap();
+        assert!(matches!(result, ParsedInstruction32::bge { .. }));
     }
 
     #[test]
     fn test_parse_btype32_bltu() {
-        let result = parse_btype32(&0b1100011, &1, &0b110, &0b00010, &0b00011).unwrap();
-        assert!(matches!(result, ParsedInstruction32::bltu {..}));
+        let result =
+            parse_btype32::<NumberedRegister>(&0b1100011, &1, &0b110, &0b00010, &0b00011).unwrap();
+        assert!(matches!(result, ParsedInstruction32::bltu { .. }));
     }
 
     #[test]
     fn test_parse_btype32_bgeu() {
-        let result = parse_btype32(&0b1100011, &1, &0b111, &0b00010, &0b00011).unwrap();
-        assert!(matches!(result, ParsedInstruction32::bgeu {..}));
+        let result =
+            parse_btype32::<NumberedRegister>(&0b1100011, &1, &0b111, &0b00010, &0b00011).unwrap();
+        assert!(matches!(result, ParsedInstruction32::bgeu { .. }));
     }
 }

--- a/src/parser/btype.rs
+++ b/src/parser/btype.rs
@@ -9,8 +9,8 @@ pub(crate) fn parse_btype32<T: Register>(
     rs1: &u8,
     rs2: &u8,
 ) -> Result<ParsedInstruction32, DisassemblerError> {
-    let rs1 = T::from_u8(*rs1)?.as_str();
-    let rs2 = T::from_u8(*rs2)?.as_str();
+    let rs1 = T::try_from_u8(*rs1)?.as_str();
+    let rs2 = T::try_from_u8(*rs2)?.as_str();
 
     match funct3 {
         0b000 => Ok(ParsedInstruction32::beq(beq {

--- a/src/parser/btype.rs
+++ b/src/parser/btype.rs
@@ -9,8 +9,8 @@ pub(crate) fn parse_btype32<T: Register>(
     rs1: &u8,
     rs2: &u8,
 ) -> Result<ParsedInstruction32, DisassemblerError> {
-    let rs1 = T::from_u8(*rs1)?.as_string();
-    let rs2 = T::from_u8(*rs2)?.as_string();
+    let rs1 = T::from_u8(*rs1)?.as_str();
+    let rs2 = T::from_u8(*rs2)?.as_str();
 
     match funct3 {
         0b000 => Ok(ParsedInstruction32::beq(beq {

--- a/src/parser/itype.rs
+++ b/src/parser/itype.rs
@@ -10,8 +10,8 @@ pub(crate) fn parse_itype32<T: Register>(
     rs1: &u8,
     imm: &i32,
 ) -> Result<ParsedInstruction32, DisassemblerError> {
-    let rd = T::from_u8(*rd)?.as_str();
-    let rs1 = T::from_u8(*rs1)?.as_str();
+    let rd = T::try_from_u8(*rd)?.as_str();
+    let rs1 = T::try_from_u8(*rs1)?.as_str();
 
     match opcode {
         0b0000011 => parse_itype32_load(funct3, rd, rs1, *imm),

--- a/src/parser/itype.rs
+++ b/src/parser/itype.rs
@@ -1,202 +1,241 @@
-use crate::instructions::{
-    ParsedInstruction32,
-    parsed_instructions::*
-};
-use crate::registers::Register;
+use crate::instructions::{parsed_instructions::*, ParsedInstruction32};
 use crate::macros::extract_bits;
+use crate::registers::Register;
 use crate::DisassemblerError;
 
-pub(crate) fn parse_itype32(opcode: &u8, rd: &u8, funct3: &u8, rs1: &u8, imm: &i32) -> Result<ParsedInstruction32, DisassemblerError> {
-    let rd = Register::try_from(*rd)?;
-    let rs1 = Register::try_from(*rs1)?;
-    
+pub(crate) fn parse_itype32<T: Register>(
+    opcode: &u8,
+    rd: &u8,
+    funct3: &u8,
+    rs1: &u8,
+    imm: &i32,
+) -> Result<ParsedInstruction32, DisassemblerError> {
+    let rd = T::from_u8(*rd)?.as_string();
+    let rs1 = T::from_u8(*rs1)?.as_string();
+
     match opcode {
         0b0000011 => parse_itype32_load(funct3, rd, rs1, *imm),
         0b0010011 => parse_itype32_alu(funct3, rd, rs1, *imm),
-        0b1100111 => Ok(ParsedInstruction32::jalr (jalr { rd, rs1, imm: *imm })),
-        0b1110011 => {
-            match imm {
-                0b000000000000 => Ok(ParsedInstruction32::ecall (ecall {})),
-                0b000000000001 => Ok(ParsedInstruction32::ebreak (ebreak {})),
-                _ => Err(DisassemblerError::InvalidImmediate(*imm)),
-            }
+        0b1100111 => Ok(ParsedInstruction32::jalr(jalr { rd, rs1, imm: *imm })),
+        0b1110011 => match imm {
+            0b000000000000 => Ok(ParsedInstruction32::ecall(ecall {})),
+            0b000000000001 => Ok(ParsedInstruction32::ebreak(ebreak {})),
+            _ => Err(DisassemblerError::InvalidImmediate(*imm)),
         },
         _ => Err(DisassemblerError::InvalidOpcode(*opcode)),
     }
 }
 
-fn parse_itype32_load(funct3: &u8, rd: Register, rs1: Register, imm: i32) -> Result<ParsedInstruction32, DisassemblerError> {
+fn parse_itype32_load(
+    funct3: &u8,
+    rd: String,
+    rs1: String,
+    imm: i32,
+) -> Result<ParsedInstruction32, DisassemblerError> {
     match funct3 {
-        0b000 => Ok(ParsedInstruction32::lb (lb { rd, rs1, imm })),
-        0b001 => Ok(ParsedInstruction32::lh (lh { rd, rs1, imm })),
-        0b010 => Ok(ParsedInstruction32::lw (lw { rd, rs1, imm })),
-        0b100 => Ok(ParsedInstruction32::lbu (lbu { rd, rs1, imm })),
-        0b101 => Ok(ParsedInstruction32::lhu (lhu { rd, rs1, imm })),
+        0b000 => Ok(ParsedInstruction32::lb(lb { rd, rs1, imm })),
+        0b001 => Ok(ParsedInstruction32::lh(lh { rd, rs1, imm })),
+        0b010 => Ok(ParsedInstruction32::lw(lw { rd, rs1, imm })),
+        0b100 => Ok(ParsedInstruction32::lbu(lbu { rd, rs1, imm })),
+        0b101 => Ok(ParsedInstruction32::lhu(lhu { rd, rs1, imm })),
         _ => Err(DisassemblerError::InvalidFunct3(*funct3)),
     }
 }
 
-fn parse_itype32_alu(funct3: &u8, rd: Register, rs1: Register, imm: i32) -> Result<ParsedInstruction32, DisassemblerError> {
+fn parse_itype32_alu(
+    funct3: &u8,
+    rd: String,
+    rs1: String,
+    imm: i32,
+) -> Result<ParsedInstruction32, DisassemblerError> {
     let imm_upper_bits = extract_bits!(imm, 5, 11)?;
     let shamt = extract_bits!(imm, 0, 4)? as u8;
 
     match funct3 {
-        0b000 => Ok(ParsedInstruction32::addi (addi { rd, rs1, imm })),
-        0b001 => Ok(ParsedInstruction32::slli (slli { rd, rs1, shamt })),
-        0b010 => Ok(ParsedInstruction32::slti (slti { rd, rs1, imm })),
-        0b011 => Ok(ParsedInstruction32::sltiu (sltiu { rd, rs1, imm })),
-        0b100 => Ok(ParsedInstruction32::xori (xori { rd, rs1, imm })),
+        0b000 => Ok(ParsedInstruction32::addi(addi { rd, rs1, imm })),
+        0b001 => Ok(ParsedInstruction32::slli(slli { rd, rs1, shamt })),
+        0b010 => Ok(ParsedInstruction32::slti(slti { rd, rs1, imm })),
+        0b011 => Ok(ParsedInstruction32::sltiu(sltiu { rd, rs1, imm })),
+        0b100 => Ok(ParsedInstruction32::xori(xori { rd, rs1, imm })),
         0b101 => match imm_upper_bits {
-            0b0000000 => Ok(ParsedInstruction32::srli (srli { rd, rs1, shamt })),
-            0b0100000 => Ok(ParsedInstruction32::srai (srai { rd, rs1, shamt })),
+            0b0000000 => Ok(ParsedInstruction32::srli(srli { rd, rs1, shamt })),
+            0b0100000 => Ok(ParsedInstruction32::srai(srai { rd, rs1, shamt })),
             _ => Err(DisassemblerError::InvalidImmediate(imm)),
         },
-        0b110 => Ok(ParsedInstruction32::ori (ori { rd, rs1, imm })),
-        0b111 => Ok(ParsedInstruction32::andi (andi { rd, rs1, imm })),
+        0b110 => Ok(ParsedInstruction32::ori(ori { rd, rs1, imm })),
+        0b111 => Ok(ParsedInstruction32::andi(andi { rd, rs1, imm })),
         _ => Err(DisassemblerError::InvalidFunct3(*funct3)),
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::registers::NumberedRegister;
 
     #[test]
     fn test_parse_itype32_lb() {
-        let result = parse_itype32(&0b0000011, &0b00001, &0b000, &0b00010, &1).unwrap();
-        assert!(matches!(result, ParsedInstruction32::lb {..}));
+        let result =
+            parse_itype32::<NumberedRegister>(&0b0000011, &0b00001, &0b000, &0b00010, &1).unwrap();
+        assert!(matches!(result, ParsedInstruction32::lb { .. }));
     }
 
     #[test]
     fn test_parse_itype32_lh() {
-        let result = parse_itype32(&0b0000011, &0b00001, &0b001, &0b00010, &1).unwrap();
-        assert!(matches!(result, ParsedInstruction32::lh {..}));
+        let result =
+            parse_itype32::<NumberedRegister>(&0b0000011, &0b00001, &0b001, &0b00010, &1).unwrap();
+        assert!(matches!(result, ParsedInstruction32::lh { .. }));
     }
 
     #[test]
     fn test_parse_itype32_lw() {
-        let result = parse_itype32(&0b0000011, &0b00001, &0b010, &0b00010, &1).unwrap();
-        assert!(matches!(result, ParsedInstruction32::lw {..}));
+        let result =
+            parse_itype32::<NumberedRegister>(&0b0000011, &0b00001, &0b010, &0b00010, &1).unwrap();
+        assert!(matches!(result, ParsedInstruction32::lw { .. }));
     }
 
     #[test]
     fn test_parse_itype32_lbu() {
-        let result = parse_itype32(&0b0000011, &0b00001, &0b100, &0b00010, &1).unwrap();
-        assert!(matches!(result, ParsedInstruction32::lbu {..}));
+        let result =
+            parse_itype32::<NumberedRegister>(&0b0000011, &0b00001, &0b100, &0b00010, &1).unwrap();
+        assert!(matches!(result, ParsedInstruction32::lbu { .. }));
     }
 
     #[test]
     fn test_parse_itype32_lhu() {
-        let result = parse_itype32(&0b0000011, &0b00001, &0b101, &0b00010, &1).unwrap();
-        assert!(matches!(result, ParsedInstruction32::lhu {..}));
+        let result =
+            parse_itype32::<NumberedRegister>(&0b0000011, &0b00001, &0b101, &0b00010, &1).unwrap();
+        assert!(matches!(result, ParsedInstruction32::lhu { .. }));
     }
 
     #[test]
     fn test_parse_itype32_load_invalid_funct3() {
-        let result = parse_itype32(&0b0000011, &0b00001, &0b110, &0b00010, &1);
+        let result = parse_itype32::<NumberedRegister>(&0b0000011, &0b00001, &0b110, &0b00010, &1);
         assert!(result.is_err());
         assert_eq!(result.err(), Some(DisassemblerError::InvalidFunct3(0b110)));
     }
 
     #[test]
     fn test_parse_itype32_addi() {
-        let result = parse_itype32(&0b0010011, &0b00001, &0b000, &0b00010, &1).unwrap();
-        assert!(matches!(result, ParsedInstruction32::addi {..}));
+        let result =
+            parse_itype32::<NumberedRegister>(&0b0010011, &0b00001, &0b000, &0b00010, &1).unwrap();
+        assert!(matches!(result, ParsedInstruction32::addi { .. }));
     }
 
     #[test]
     fn test_parse_itype32_slli() {
-        let result = parse_itype32(&0b0010011, &0b00001, &0b001, &0b00010, &1).unwrap();
-        assert!(matches!(result, ParsedInstruction32::slli {..}));
+        let result =
+            parse_itype32::<NumberedRegister>(&0b0010011, &0b00001, &0b001, &0b00010, &1).unwrap();
+        assert!(matches!(result, ParsedInstruction32::slli { .. }));
     }
 
     #[test]
     fn test_parse_itype32_slti() {
-        let result = parse_itype32(&0b0010011, &0b00001, &0b010, &0b00010, &1).unwrap();
-        assert!(matches!(result, ParsedInstruction32::slti {..}));
+        let result =
+            parse_itype32::<NumberedRegister>(&0b0010011, &0b00001, &0b010, &0b00010, &1).unwrap();
+        assert!(matches!(result, ParsedInstruction32::slti { .. }));
     }
 
     #[test]
     fn test_parse_itype32_sltiu() {
-        let result = parse_itype32(&0b0010011, &0b00001, &0b011, &0b00010, &1).unwrap();
-        assert!(matches!(result, ParsedInstruction32::sltiu {..}));
+        let result =
+            parse_itype32::<NumberedRegister>(&0b0010011, &0b00001, &0b011, &0b00010, &1).unwrap();
+        assert!(matches!(result, ParsedInstruction32::sltiu { .. }));
     }
 
     #[test]
     fn test_parse_itype32_xori() {
-        let result = parse_itype32(&0b0010011, &0b00001, &0b100, &0b00010, &1).unwrap();
-        assert!(matches!(result, ParsedInstruction32::xori {..}));
+        let result =
+            parse_itype32::<NumberedRegister>(&0b0010011, &0b00001, &0b100, &0b00010, &1).unwrap();
+        assert!(matches!(result, ParsedInstruction32::xori { .. }));
     }
 
     #[test]
     fn test_parse_itype32_srli() {
-        let result = parse_itype32(&0b0010011, &0b00001, &0b101, &0b00010, &1).unwrap();
-        assert!(matches!(result, ParsedInstruction32::srli {..}));
+        let result =
+            parse_itype32::<NumberedRegister>(&0b0010011, &0b00001, &0b101, &0b00010, &1).unwrap();
+        assert!(matches!(result, ParsedInstruction32::srli { .. }));
     }
 
     #[test]
     fn test_parse_itype32_srai() {
-        let result = parse_itype32(&0b0010011, &0b00001, &0b101, &0b00010, &1025).unwrap();
-        assert!(matches!(result, ParsedInstruction32::srai {..}));
+        let result =
+            parse_itype32::<NumberedRegister>(&0b0010011, &0b00001, &0b101, &0b00010, &1025)
+                .unwrap();
+        assert!(matches!(result, ParsedInstruction32::srai { .. }));
     }
 
     #[test]
     fn test_parse_itype32_ori() {
-        let result = parse_itype32(&0b0010011, &0b00001, &0b110, &0b00010, &1).unwrap();
-        assert!(matches!(result, ParsedInstruction32::ori {..}));
+        let result =
+            parse_itype32::<NumberedRegister>(&0b0010011, &0b00001, &0b110, &0b00010, &1).unwrap();
+        assert!(matches!(result, ParsedInstruction32::ori { .. }));
     }
 
     #[test]
     fn test_parse_itype32_andi() {
-        let result = parse_itype32(&0b0010011, &0b00001, &0b111, &0b00010, &1).unwrap();
-        assert!(matches!(result, ParsedInstruction32::andi {..}));
+        let result =
+            parse_itype32::<NumberedRegister>(&0b0010011, &0b00001, &0b111, &0b00010, &1).unwrap();
+        assert!(matches!(result, ParsedInstruction32::andi { .. }));
     }
 
     #[test]
     fn test_parse_itype32_invalid_funct3() {
-        let result = parse_itype32(&0b0010011, &0b00001, &0b1000, &0b00010, &1);
+        let result = parse_itype32::<NumberedRegister>(&0b0010011, &0b00001, &0b1000, &0b00010, &1);
         assert!(result.is_err());
         assert_eq!(result.err(), Some(DisassemblerError::InvalidFunct3(0b1000)));
     }
 
     #[test]
     fn test_parse_itype32_invalid_imm() {
-        let exp_imm:i32 = -2047;
-        let result = parse_itype32(&0b0010011, &0b00001, &0b101, &0b00010, &-2047);
+        let exp_imm: i32 = -2047;
+        let result =
+            parse_itype32::<NumberedRegister>(&0b0010011, &0b00001, &0b101, &0b00010, &-2047);
         assert!(result.is_err());
-        assert_eq!(result.err(), Some(DisassemblerError::InvalidImmediate(exp_imm)));
+        assert_eq!(
+            result.err(),
+            Some(DisassemblerError::InvalidImmediate(exp_imm))
+        );
     }
 
     #[test]
     fn test_parse_itype32_jalr() {
-        let result = parse_itype32(&0b1100111, &0b00001, &0b000, &0b00010, &1).unwrap();
-        assert!(matches!(result, ParsedInstruction32::jalr {..}));
+        let result =
+            parse_itype32::<NumberedRegister>(&0b1100111, &0b00001, &0b000, &0b00010, &1).unwrap();
+        assert!(matches!(result, ParsedInstruction32::jalr { .. }));
     }
 
     #[test]
     fn test_parse_itype32_ecall() {
-        let result = parse_itype32(&0b1110011, &0b00000, &0b000, &0b00000, &0).unwrap();
-        assert!(matches!(result, ParsedInstruction32::ecall (ecall {})));
+        let result =
+            parse_itype32::<NumberedRegister>(&0b1110011, &0b00000, &0b000, &0b00000, &0).unwrap();
+        assert!(matches!(result, ParsedInstruction32::ecall(ecall {})));
     }
 
     #[test]
     fn test_parse_itype32_ebreak() {
-        let result = parse_itype32(&0b1110011, &0b00000, &0b000, &0b00000, &1).unwrap();
-        assert!(matches!(result, ParsedInstruction32::ebreak (ebreak {})));
+        let result =
+            parse_itype32::<NumberedRegister>(&0b1110011, &0b00000, &0b000, &0b00000, &1).unwrap();
+        assert!(matches!(result, ParsedInstruction32::ebreak(ebreak {})));
     }
 
     #[test]
     fn test_parse_itype32_invalid_opcode() {
-        let result = parse_itype32(&0b1111111, &0b00001, &0b000, &0b00010, &1);
+        let result = parse_itype32::<NumberedRegister>(&0b1111111, &0b00001, &0b000, &0b00010, &1);
         assert!(result.is_err());
-        assert_eq!(result.err(), Some(DisassemblerError::InvalidOpcode(0b1111111)));
+        assert_eq!(
+            result.err(),
+            Some(DisassemblerError::InvalidOpcode(0b1111111))
+        );
     }
 
     #[test]
     fn test_parse_itype32_invalid_funct3_ecall_ebreak() {
-        let result = parse_itype32(&0b1110011, &0b00000, &0b000, &0b00000, &2);
+        let result = parse_itype32::<NumberedRegister>(&0b1110011, &0b00000, &0b000, &0b00000, &2);
         assert!(result.is_err());
-        assert_eq!(result.err(), Some(DisassemblerError::InvalidImmediate(0b000000000010)));
+        assert_eq!(
+            result.err(),
+            Some(DisassemblerError::InvalidImmediate(0b000000000010))
+        );
     }
 }

--- a/src/parser/itype.rs
+++ b/src/parser/itype.rs
@@ -10,8 +10,8 @@ pub(crate) fn parse_itype32<T: Register>(
     rs1: &u8,
     imm: &i32,
 ) -> Result<ParsedInstruction32, DisassemblerError> {
-    let rd = T::from_u8(*rd)?.as_string();
-    let rs1 = T::from_u8(*rs1)?.as_string();
+    let rd = T::from_u8(*rd)?.as_str();
+    let rs1 = T::from_u8(*rs1)?.as_str();
 
     match opcode {
         0b0000011 => parse_itype32_load(funct3, rd, rs1, *imm),
@@ -28,8 +28,8 @@ pub(crate) fn parse_itype32<T: Register>(
 
 fn parse_itype32_load(
     funct3: &u8,
-    rd: String,
-    rs1: String,
+    rd: &'static str,
+    rs1: &'static str,
     imm: i32,
 ) -> Result<ParsedInstruction32, DisassemblerError> {
     match funct3 {
@@ -44,8 +44,8 @@ fn parse_itype32_load(
 
 fn parse_itype32_alu(
     funct3: &u8,
-    rd: String,
-    rs1: String,
+    rd: &'static str,
+    rs1: &'static str,
     imm: i32,
 ) -> Result<ParsedInstruction32, DisassemblerError> {
     let imm_upper_bits = extract_bits!(imm, 5, 11)?;

--- a/src/parser/jtype.rs
+++ b/src/parser/jtype.rs
@@ -1,16 +1,16 @@
-use crate::instructions::{
-    ParsedInstruction32,
-    parsed_instructions::*
-};
+use crate::instructions::{parsed_instructions::*, ParsedInstruction32};
 use crate::registers::Register;
 use crate::DisassemblerError;
 
-pub(crate) fn parse_jtype32(opcode: &u8, rd: &u8, imm: &i32) -> Result<ParsedInstruction32, DisassemblerError> {
-    let rd = Register::try_from(*rd)?;
-
+pub(crate) fn parse_jtype32<T: Register>(
+    opcode: &u8,
+    rd: &u8,
+    imm: &i32,
+) -> Result<ParsedInstruction32, DisassemblerError> {
+    let rd = T::from_u8(*rd)?.as_string();
 
     match opcode {
-        0b1101111 => Ok(ParsedInstruction32::jal (jal { rd, imm: *imm})),
+        0b1101111 => Ok(ParsedInstruction32::jal(jal { rd, imm: *imm })),
         _ => Err(DisassemblerError::InvalidOpcode(*opcode)),
     }
 }
@@ -18,18 +18,22 @@ pub(crate) fn parse_jtype32(opcode: &u8, rd: &u8, imm: &i32) -> Result<ParsedIns
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::instructions::ParsedInstruction32;
+    use crate::{instructions::ParsedInstruction32, registers::NumberedRegister};
 
     #[test]
     fn test_parse_jtype32_jal() {
-        let result = parse_jtype32(&0b1101111, &0b00010, &1).unwrap();
-        assert!(matches!(result, ParsedInstruction32::jal {..}));
+        let result = parse_jtype32::<NumberedRegister>(&0b1101111, &0b00010, &1).unwrap();
+        assert!(matches!(result, ParsedInstruction32::jal { .. }));
     }
 
     #[test]
     fn test_parse_jtype32_invalid_opcode() {
-        let result = parse_jtype32(&0b0000000, &0b00010, &1);
+        let result = parse_jtype32::<NumberedRegister>(&0b0000000, &0b00010, &1);
         assert!(result.is_err());
-        assert_eq!(result.err(), Some(DisassemblerError::InvalidOpcode(0b0000000)));
+        assert_eq!(
+            result.err(),
+            Some(DisassemblerError::InvalidOpcode(0b0000000))
+        );
     }
 }
+

--- a/src/parser/jtype.rs
+++ b/src/parser/jtype.rs
@@ -7,7 +7,7 @@ pub(crate) fn parse_jtype32<T: Register>(
     rd: &u8,
     imm: &i32,
 ) -> Result<ParsedInstruction32, DisassemblerError> {
-    let rd = T::from_u8(*rd)?.as_str();
+    let rd = T::try_from_u8(*rd)?.as_str();
 
     match opcode {
         0b1101111 => Ok(ParsedInstruction32::jal(jal { rd, imm: *imm })),

--- a/src/parser/jtype.rs
+++ b/src/parser/jtype.rs
@@ -7,7 +7,7 @@ pub(crate) fn parse_jtype32<T: Register>(
     rd: &u8,
     imm: &i32,
 ) -> Result<ParsedInstruction32, DisassemblerError> {
-    let rd = T::from_u8(*rd)?.as_string();
+    let rd = T::from_u8(*rd)?.as_str();
 
     match opcode {
         0b1101111 => Ok(ParsedInstruction32::jal(jal { rd, imm: *imm })),
@@ -36,4 +36,3 @@ mod tests {
         );
     }
 }
-

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1,36 +1,55 @@
 use crate::instructions::{DecodedInstruction32, ParseInstruction32, ParsedInstruction32};
-use crate::DisassemblerError;
-use crate::parser::rtype::parse_rtype32;
-use crate::parser::itype::parse_itype32;
-use crate::parser::stype::parse_stype32;
 use crate::parser::btype::parse_btype32;
-use crate::parser::utype::parse_utype32;
+use crate::parser::itype::parse_itype32;
 use crate::parser::jtype::parse_jtype32;
-
+use crate::parser::rtype::parse_rtype32;
+use crate::parser::stype::parse_stype32;
+use crate::parser::utype::parse_utype32;
+use crate::{DisassemblerError, Register};
 
 impl ParseInstruction32 for DecodedInstruction32 {
-    fn parse_instruction32(&self) -> Result<ParsedInstruction32, DisassemblerError> {
+    fn parse_instruction32<T: Register>(&self) -> Result<ParsedInstruction32, DisassemblerError> {
         match self {
-            DecodedInstruction32::RType { opcode, rd, funct3, rs1, rs2, funct7 } => 
-                parse_rtype32(opcode, rd, funct3, rs1, rs2, funct7),
-            DecodedInstruction32::IType { opcode, rd, funct3, rs1, imm } =>
-                parse_itype32(opcode, rd, funct3, rs1, imm),
-            DecodedInstruction32::SType { opcode, imm, funct3, rs1, rs2 } =>
-                parse_stype32(opcode, imm, funct3, rs1, rs2),
-            DecodedInstruction32::BType { opcode, imm, funct3, rs1, rs2 } =>
-                parse_btype32(opcode, imm, funct3, rs1, rs2),
-            DecodedInstruction32::UType { opcode, rd, imm } =>
-                parse_utype32(opcode, rd, imm),
-            DecodedInstruction32::JType { opcode, rd, imm } =>
-                parse_jtype32(opcode, rd, imm),
+            DecodedInstruction32::RType {
+                opcode,
+                rd,
+                funct3,
+                rs1,
+                rs2,
+                funct7,
+            } => parse_rtype32::<T>(opcode, rd, funct3, rs1, rs2, funct7),
+            DecodedInstruction32::IType {
+                opcode,
+                rd,
+                funct3,
+                rs1,
+                imm,
+            } => parse_itype32::<T>(opcode, rd, funct3, rs1, imm),
+            DecodedInstruction32::SType {
+                opcode,
+                imm,
+                funct3,
+                rs1,
+                rs2,
+            } => parse_stype32::<T>(opcode, imm, funct3, rs1, rs2),
+            DecodedInstruction32::BType {
+                opcode,
+                imm,
+                funct3,
+                rs1,
+                rs2,
+            } => parse_btype32::<T>(opcode, imm, funct3, rs1, rs2),
+            DecodedInstruction32::UType { opcode, rd, imm } => parse_utype32::<T>(opcode, rd, imm),
+            DecodedInstruction32::JType { opcode, rd, imm } => parse_jtype32::<T>(opcode, rd, imm),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::registers::NumberedRegister;
 
+    use super::*;
 
     #[test]
     fn test_parse_instruction32_rtype_add() {
@@ -42,8 +61,8 @@ mod tests {
             rs2: 0b00011,
             funct7: 0b0000000,
         };
-        let result = decoded.parse_instruction32().unwrap();
-        assert!(matches!(result, ParsedInstruction32::add {..}));
+        let result = decoded.parse_instruction32::<NumberedRegister>().unwrap();
+        assert!(matches!(result, ParsedInstruction32::add { .. }));
     }
 
     #[test]
@@ -55,8 +74,8 @@ mod tests {
             rs1: 0b00010,
             imm: 1,
         };
-        let result = decoded.parse_instruction32().unwrap();
-        assert!(matches!(result, ParsedInstruction32::addi {..}));
+        let result = decoded.parse_instruction32::<NumberedRegister>().unwrap();
+        assert!(matches!(result, ParsedInstruction32::addi { .. }));
     }
 
     #[test]
@@ -68,8 +87,8 @@ mod tests {
             rs1: 0b00010,
             rs2: 0b00011,
         };
-        let result = decoded.parse_instruction32().unwrap();
-        assert!(matches!(result, ParsedInstruction32::sb {..}));
+        let result = decoded.parse_instruction32::<NumberedRegister>().unwrap();
+        assert!(matches!(result, ParsedInstruction32::sb { .. }));
     }
 
     #[test]
@@ -81,8 +100,8 @@ mod tests {
             rs1: 0b00010,
             rs2: 0b00011,
         };
-        let result = decoded.parse_instruction32().unwrap();
-        assert!(matches!(result, ParsedInstruction32::beq {..}));
+        let result = decoded.parse_instruction32::<NumberedRegister>().unwrap();
+        assert!(matches!(result, ParsedInstruction32::beq { .. }));
     }
 
     #[test]
@@ -92,8 +111,8 @@ mod tests {
             rd: 0b00001,
             imm: (1 as i32) << 12,
         };
-        let result = decoded.parse_instruction32().unwrap();
-        assert!(matches!(result, ParsedInstruction32::lui {..}));
+        let result = decoded.parse_instruction32::<NumberedRegister>().unwrap();
+        assert!(matches!(result, ParsedInstruction32::lui { .. }));
     }
 
     #[test]
@@ -103,7 +122,8 @@ mod tests {
             rd: 0b00001,
             imm: 1,
         };
-        let result = decoded.parse_instruction32().unwrap();
-        assert!(matches!(result, ParsedInstruction32::jal {..}));
+        let result = decoded.parse_instruction32::<NumberedRegister>().unwrap();
+        assert!(matches!(result, ParsedInstruction32::jal { .. }));
     }
 }
+

--- a/src/parser/rtype.rs
+++ b/src/parser/rtype.rs
@@ -10,9 +10,9 @@ pub(crate) fn parse_rtype32<T: Register>(
     rs2: &u8,
     funct7: &u8,
 ) -> Result<ParsedInstruction32, DisassemblerError> {
-    let rd = T::from_u8(*rd)?.as_str();
-    let rs1 = T::from_u8(*rs1)?.as_str();
-    let rs2 = T::from_u8(*rs2)?.as_str();
+    let rd = T::try_from_u8(*rd)?.as_str();
+    let rs1 = T::try_from_u8(*rs1)?.as_str();
+    let rs2 = T::try_from_u8(*rs2)?.as_str();
 
     match funct3 {
         0b000 => match funct7 {

--- a/src/parser/rtype.rs
+++ b/src/parser/rtype.rs
@@ -1,118 +1,231 @@
-use crate::instructions::{
-    ParsedInstruction32,
-    parsed_instructions::*
-};
+use crate::instructions::{parsed_instructions::*, ParsedInstruction32};
 use crate::registers::Register;
 use crate::DisassemblerError;
 
-pub(crate) fn parse_rtype32(_opcode: &u8, rd: &u8, funct3: &u8, rs1: &u8, rs2: &u8, funct7: &u8) -> Result<ParsedInstruction32, DisassemblerError> {
-    let rd = Register::try_from(*rd)?;
-    let rs1 = Register::try_from(*rs1)?;
-    let rs2 = Register::try_from(*rs2)?;
-    
+pub(crate) fn parse_rtype32<T: Register>(
+    _opcode: &u8,
+    rd: &u8,
+    funct3: &u8,
+    rs1: &u8,
+    rs2: &u8,
+    funct7: &u8,
+) -> Result<ParsedInstruction32, DisassemblerError> {
+    let rd = T::from_u8(*rd)?.as_string();
+    let rs1 = T::from_u8(*rs1)?.as_string();
+    let rs2 = T::from_u8(*rs2)?.as_string();
+
     match funct3 {
         0b000 => match funct7 {
-            0b0000000 => Ok(ParsedInstruction32::add (add { rd, rs1, rs2 })),
-            0b0100000 => Ok(ParsedInstruction32::sub (sub { rd, rs1, rs2 })),
+            0b0000000 => Ok(ParsedInstruction32::add(add { rd, rs1, rs2 })),
+            0b0100000 => Ok(ParsedInstruction32::sub(sub { rd, rs1, rs2 })),
             _ => Err(DisassemblerError::InvalidFunct7(*funct7)),
         },
-        0b001 => Ok(ParsedInstruction32::sll (sll { rd, rs1, rs2 })),
-        0b010 => Ok(ParsedInstruction32::slt (slt { rd, rs1, rs2 })),
-        0b011 => Ok(ParsedInstruction32::sltu (sltu { rd, rs1, rs2 })),
-        0b100 => Ok(ParsedInstruction32::xor (xor { rd, rs1, rs2 })),
+        0b001 => Ok(ParsedInstruction32::sll(sll { rd, rs1, rs2 })),
+        0b010 => Ok(ParsedInstruction32::slt(slt { rd, rs1, rs2 })),
+        0b011 => Ok(ParsedInstruction32::sltu(sltu { rd, rs1, rs2 })),
+        0b100 => Ok(ParsedInstruction32::xor(xor { rd, rs1, rs2 })),
         0b101 => match funct7 {
-            0b0000000 => Ok(ParsedInstruction32::srl (srl { rd, rs1, rs2 })),
-            0b0100000 => Ok(ParsedInstruction32::sra (sra { rd, rs1, rs2 })),
+            0b0000000 => Ok(ParsedInstruction32::srl(srl { rd, rs1, rs2 })),
+            0b0100000 => Ok(ParsedInstruction32::sra(sra { rd, rs1, rs2 })),
             _ => Err(DisassemblerError::InvalidFunct7(*funct7)),
         },
-        0b110 => Ok(ParsedInstruction32::or (or { rd, rs1, rs2 })),
-        0b111 => Ok(ParsedInstruction32::and (and { rd, rs1, rs2 })),
+        0b110 => Ok(ParsedInstruction32::or(or { rd, rs1, rs2 })),
+        0b111 => Ok(ParsedInstruction32::and(and { rd, rs1, rs2 })),
         _ => Err(DisassemblerError::InvalidFunct3(*funct3)),
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::registers::NumberedRegister;
+
     use super::*;
 
     #[test]
     fn test_parse_rtype32_add() {
-        let result = parse_rtype32(&0b00000000, &0b00000001, &0b000, &0b00000010, &0b00000011, &0b0000000).unwrap();
-        assert!(matches!(result, ParsedInstruction32::add {..}));
+        let result = parse_rtype32::<NumberedRegister>(
+            &0b00000000,
+            &0b00000001,
+            &0b000,
+            &0b00000010,
+            &0b00000011,
+            &0b0000000,
+        )
+        .unwrap();
+        assert!(matches!(result, ParsedInstruction32::add { .. }));
     }
 
     #[test]
     fn test_parse_rtype32_sub() {
-        let result = parse_rtype32(&0b00000000, &0b00000001, &0b000, &0b00000010, &0b00000011, &0b0100000).unwrap();
-        assert!(matches!(result, ParsedInstruction32::sub {..}));
+        let result = parse_rtype32::<NumberedRegister>(
+            &0b00000000,
+            &0b00000001,
+            &0b000,
+            &0b00000010,
+            &0b00000011,
+            &0b0100000,
+        )
+        .unwrap();
+        assert!(matches!(result, ParsedInstruction32::sub { .. }));
     }
 
     #[test]
     fn test_parse_rtype32_sll() {
-        let result = parse_rtype32(&0b00000000, &0b00000001, &0b001, &0b00000010, &0b00000011, &0b0000000).unwrap();
-        assert!(matches!(result, ParsedInstruction32::sll {..}));
+        let result = parse_rtype32::<NumberedRegister>(
+            &0b00000000,
+            &0b00000001,
+            &0b001,
+            &0b00000010,
+            &0b00000011,
+            &0b0000000,
+        )
+        .unwrap();
+        assert!(matches!(result, ParsedInstruction32::sll { .. }));
     }
 
     #[test]
     fn test_parse_rtype32_slt() {
-        let result = parse_rtype32(&0b00000000, &0b00000001, &0b010, &0b00000010, &0b00000011, &0b0000000).unwrap();
-        assert!(matches!(result, ParsedInstruction32::slt {..}));
+        let result = parse_rtype32::<NumberedRegister>(
+            &0b00000000,
+            &0b00000001,
+            &0b010,
+            &0b00000010,
+            &0b00000011,
+            &0b0000000,
+        )
+        .unwrap();
+        assert!(matches!(result, ParsedInstruction32::slt { .. }));
     }
 
     #[test]
     fn test_parse_rtype32_sltu() {
-        let result = parse_rtype32(&0b00000000, &0b00000001, &0b011, &0b00000010, &0b00000011, &0b0000000).unwrap();
-        assert!(matches!(result, ParsedInstruction32::sltu {..}));
+        let result = parse_rtype32::<NumberedRegister>(
+            &0b00000000,
+            &0b00000001,
+            &0b011,
+            &0b00000010,
+            &0b00000011,
+            &0b0000000,
+        )
+        .unwrap();
+        assert!(matches!(result, ParsedInstruction32::sltu { .. }));
     }
 
     #[test]
     fn test_parse_rtype32_xor() {
-        let result = parse_rtype32(&0b00000000, &0b00000001, &0b100, &0b00000010, &0b00000011, &0b0000000).unwrap();
-        assert!(matches!(result, ParsedInstruction32::xor {..}));
+        let result = parse_rtype32::<NumberedRegister>(
+            &0b00000000,
+            &0b00000001,
+            &0b100,
+            &0b00000010,
+            &0b00000011,
+            &0b0000000,
+        )
+        .unwrap();
+        assert!(matches!(result, ParsedInstruction32::xor { .. }));
     }
 
     #[test]
     fn test_parse_rtype32_srl() {
-        let result = parse_rtype32(&0b00000000, &0b00000001, &0b101, &0b00000010, &0b00000011, &0b0000000).unwrap();
-        assert!(matches!(result, ParsedInstruction32::srl {..}));
+        let result = parse_rtype32::<NumberedRegister>(
+            &0b00000000,
+            &0b00000001,
+            &0b101,
+            &0b00000010,
+            &0b00000011,
+            &0b0000000,
+        )
+        .unwrap();
+        assert!(matches!(result, ParsedInstruction32::srl { .. }));
     }
 
     #[test]
     fn test_parse_rtype32_sra() {
-        let result = parse_rtype32(&0b00000000, &0b00000001, &0b101, &0b00000010, &0b00000011, &0b0100000).unwrap();
-        assert!(matches!(result, ParsedInstruction32::sra {..}));
+        let result = parse_rtype32::<NumberedRegister>(
+            &0b00000000,
+            &0b00000001,
+            &0b101,
+            &0b00000010,
+            &0b00000011,
+            &0b0100000,
+        )
+        .unwrap();
+        assert!(matches!(result, ParsedInstruction32::sra { .. }));
     }
 
     #[test]
     fn test_parse_rtype32_or() {
-        let result = parse_rtype32(&0b00000000, &0b00000001, &0b110, &0b00000010, &0b00000011, &0b0000000).unwrap();
-        assert!(matches!(result, ParsedInstruction32::or {..}));
+        let result = parse_rtype32::<NumberedRegister>(
+            &0b00000000,
+            &0b00000001,
+            &0b110,
+            &0b00000010,
+            &0b00000011,
+            &0b0000000,
+        )
+        .unwrap();
+        assert!(matches!(result, ParsedInstruction32::or { .. }));
     }
 
     #[test]
     fn test_parse_rtype32_and() {
-        let result = parse_rtype32(&0b00000000, &0b00000001, &0b111, &0b00000010, &0b00000011, &0b0000000).unwrap();
-        assert!(matches!(result, ParsedInstruction32::and {..}));
+        let result = parse_rtype32::<NumberedRegister>(
+            &0b00000000,
+            &0b00000001,
+            &0b111,
+            &0b00000010,
+            &0b00000011,
+            &0b0000000,
+        )
+        .unwrap();
+        assert!(matches!(result, ParsedInstruction32::and { .. }));
     }
 
     #[test]
     fn test_parse_rtype32_invalid_funct3() {
-        let result = parse_rtype32(&0b00000000, &0b00000001, &0b1000, &0b00000010, &0b00000011, &0b0000000);
+        let result = parse_rtype32::<NumberedRegister>(
+            &0b00000000,
+            &0b00000001,
+            &0b1000,
+            &0b00000010,
+            &0b00000011,
+            &0b0000000,
+        );
         assert!(result.is_err());
         assert_eq!(result.err(), Some(DisassemblerError::InvalidFunct3(0b1000)));
     }
 
     #[test]
     fn test_parse_rtype32_invalid_funct7() {
-        let result = parse_rtype32(&0b00000000, &0b00000001, &0b000, &0b00000010, &0b00000011, &0b1000000);
+        let result = parse_rtype32::<NumberedRegister>(
+            &0b00000000,
+            &0b00000001,
+            &0b000,
+            &0b00000010,
+            &0b00000011,
+            &0b1000000,
+        );
         assert!(result.is_err());
-        assert_eq!(result.err(), Some(DisassemblerError::InvalidFunct7(0b1000000)));
+        assert_eq!(
+            result.err(),
+            Some(DisassemblerError::InvalidFunct7(0b1000000))
+        );
     }
 
     #[test]
     fn test_parse_rtype32_invalid_funct7_for_funct3_101() {
-        let result = parse_rtype32(&0b00000000, &0b00000001, &0b101, &0b00000010, &0b00000011, &0b0010000);
+        let result = parse_rtype32::<NumberedRegister>(
+            &0b00000000,
+            &0b00000001,
+            &0b101,
+            &0b00000010,
+            &0b00000011,
+            &0b0010000,
+        );
         assert!(result.is_err());
-        assert_eq!(result.err(), Some(DisassemblerError::InvalidFunct7(0b0010000)));
+        assert_eq!(
+            result.err(),
+            Some(DisassemblerError::InvalidFunct7(0b0010000))
+        );
     }
 }

--- a/src/parser/rtype.rs
+++ b/src/parser/rtype.rs
@@ -10,9 +10,9 @@ pub(crate) fn parse_rtype32<T: Register>(
     rs2: &u8,
     funct7: &u8,
 ) -> Result<ParsedInstruction32, DisassemblerError> {
-    let rd = T::from_u8(*rd)?.as_string();
-    let rs1 = T::from_u8(*rs1)?.as_string();
-    let rs2 = T::from_u8(*rs2)?.as_string();
+    let rd = T::from_u8(*rd)?.as_str();
+    let rs1 = T::from_u8(*rs1)?.as_str();
+    let rs2 = T::from_u8(*rs2)?.as_str();
 
     match funct3 {
         0b000 => match funct7 {

--- a/src/parser/stype.rs
+++ b/src/parser/stype.rs
@@ -9,8 +9,8 @@ pub(crate) fn parse_stype32<T: Register>(
     rs1: &u8,
     rs2: &u8,
 ) -> Result<ParsedInstruction32, DisassemblerError> {
-    let rs1 = T::from_u8(*rs1)?.as_str();
-    let rs2 = T::from_u8(*rs2)?.as_str();
+    let rs1 = T::try_from_u8(*rs1)?.as_str();
+    let rs2 = T::try_from_u8(*rs2)?.as_str();
 
     match funct3 {
         0b000 => Ok(ParsedInstruction32::sb(sb {

--- a/src/parser/stype.rs
+++ b/src/parser/stype.rs
@@ -1,18 +1,33 @@
-use crate::instructions::{
-    ParsedInstruction32,
-    parsed_instructions::*
-};
+use crate::instructions::{parsed_instructions::*, ParsedInstruction32};
 use crate::registers::Register;
 use crate::DisassemblerError;
 
-pub(crate) fn parse_stype32(_opcode: &u8, imm: &i32, funct3: &u8, rs1: &u8, rs2: &u8) -> Result<ParsedInstruction32, DisassemblerError> {
-    let rs1 = Register::try_from(*rs1)?;
-    let rs2 = Register::try_from(*rs2)?;
+pub(crate) fn parse_stype32<T: Register>(
+    _opcode: &u8,
+    imm: &i32,
+    funct3: &u8,
+    rs1: &u8,
+    rs2: &u8,
+) -> Result<ParsedInstruction32, DisassemblerError> {
+    let rs1 = T::from_u8(*rs1)?.as_string();
+    let rs2 = T::from_u8(*rs2)?.as_string();
 
     match funct3 {
-        0b000 => Ok(ParsedInstruction32::sb (sb { rs1, rs2, imm: *imm })),
-        0b001 => Ok(ParsedInstruction32::sh (sh { rs1, rs2, imm: *imm })),
-        0b010 => Ok(ParsedInstruction32::sw (sw { rs1, rs2, imm: *imm })),
+        0b000 => Ok(ParsedInstruction32::sb(sb {
+            rs1,
+            rs2,
+            imm: *imm,
+        })),
+        0b001 => Ok(ParsedInstruction32::sh(sh {
+            rs1,
+            rs2,
+            imm: *imm,
+        })),
+        0b010 => Ok(ParsedInstruction32::sw(sw {
+            rs1,
+            rs2,
+            imm: *imm,
+        })),
         _ => Err(DisassemblerError::InvalidFunct3(*funct3)),
     }
 }
@@ -20,28 +35,32 @@ pub(crate) fn parse_stype32(_opcode: &u8, imm: &i32, funct3: &u8, rs1: &u8, rs2:
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::registers::NumberedRegister;
 
     #[test]
     fn test_parse_stype32_sb() {
-        let result = parse_stype32(&0b0100011, &1, &0b000, &0b00010, &0b00011).unwrap();
-        assert!(matches!(result, ParsedInstruction32::sb {..}));
+        let result =
+            parse_stype32::<NumberedRegister>(&0b0100011, &1, &0b000, &0b00010, &0b00011).unwrap();
+        assert!(matches!(result, ParsedInstruction32::sb { .. }));
     }
 
     #[test]
     fn test_parse_stype32_sh() {
-        let result = parse_stype32(&0b0100011, &1, &0b001, &0b00010, &0b00011).unwrap();
-        assert!(matches!(result, ParsedInstruction32::sh {..}));
+        let result =
+            parse_stype32::<NumberedRegister>(&0b0100011, &1, &0b001, &0b00010, &0b00011).unwrap();
+        assert!(matches!(result, ParsedInstruction32::sh { .. }));
     }
 
     #[test]
     fn test_parse_stype32_sw() {
-        let result = parse_stype32(&0b0100011, &1, &0b010, &0b00010, &0b00011).unwrap();
-        assert!(matches!(result, ParsedInstruction32::sw {..}));
+        let result =
+            parse_stype32::<NumberedRegister>(&0b0100011, &1, &0b010, &0b00010, &0b00011).unwrap();
+        assert!(matches!(result, ParsedInstruction32::sw { .. }));
     }
 
     #[test]
     fn test_parse_stype32_invalid_funct3() {
-        let result = parse_stype32(&0b0100011, &1, &0b011, &0b00010, &0b00011);
+        let result = parse_stype32::<NumberedRegister>(&0b0100011, &1, &0b011, &0b00010, &0b00011);
         assert!(result.is_err());
         assert_eq!(result.err(), Some(DisassemblerError::InvalidFunct3(0b011)));
     }

--- a/src/parser/stype.rs
+++ b/src/parser/stype.rs
@@ -9,8 +9,8 @@ pub(crate) fn parse_stype32<T: Register>(
     rs1: &u8,
     rs2: &u8,
 ) -> Result<ParsedInstruction32, DisassemblerError> {
-    let rs1 = T::from_u8(*rs1)?.as_string();
-    let rs2 = T::from_u8(*rs2)?.as_string();
+    let rs1 = T::from_u8(*rs1)?.as_str();
+    let rs2 = T::from_u8(*rs2)?.as_str();
 
     match funct3 {
         0b000 => Ok(ParsedInstruction32::sb(sb {

--- a/src/parser/utype.rs
+++ b/src/parser/utype.rs
@@ -1,16 +1,17 @@
-use crate::instructions::{
-    ParsedInstruction32,
-    parsed_instructions::*
-};
+use crate::instructions::{parsed_instructions::*, ParsedInstruction32};
 use crate::registers::Register;
 use crate::DisassemblerError;
 
-pub(crate) fn parse_utype32(opcode: &u8, rd: &u8, imm: &i32) -> Result<ParsedInstruction32, DisassemblerError> {
-    let rd = Register::try_from(*rd)?;
-    
+pub(crate) fn parse_utype32<T: Register>(
+    opcode: &u8,
+    rd: &u8,
+    imm: &i32,
+) -> Result<ParsedInstruction32, DisassemblerError> {
+    let rd = T::from_u8(*rd)?.as_string();
+
     match opcode {
-        0b0110111 => Ok(ParsedInstruction32::lui (lui { rd, imm: *imm })),
-        0b0010111 => Ok(ParsedInstruction32::auipc (auipc { rd, imm: *imm })),
+        0b0110111 => Ok(ParsedInstruction32::lui(lui { rd, imm: *imm })),
+        0b0010111 => Ok(ParsedInstruction32::auipc(auipc { rd, imm: *imm })),
         _ => Err(DisassemblerError::InvalidOpcode(*opcode)),
     }
 }
@@ -19,26 +20,30 @@ pub(crate) fn parse_utype32(opcode: &u8, rd: &u8, imm: &i32) -> Result<ParsedIns
 mod tests {
     use super::*;
     use crate::instructions::ParsedInstruction32;
+    use crate::registers::NumberedRegister;
 
     #[test]
     fn test_parse_utype32_lui() {
         let imm = 1 << 12;
-        let result = parse_utype32(&0b0110111, &0b00010, &imm).unwrap();
-        assert!(matches!(result, ParsedInstruction32::lui {..}));
+        let result = parse_utype32::<NumberedRegister>(&0b0110111, &0b00010, &imm).unwrap();
+        assert!(matches!(result, ParsedInstruction32::lui { .. }));
     }
 
     #[test]
     fn test_parse_utype32_auipc() {
         let imm = 1 << 12;
-        let result = parse_utype32(&0b0010111, &0b00010, &imm).unwrap();
-        assert!(matches!(result, ParsedInstruction32::auipc {..}));
+        let result = parse_utype32::<NumberedRegister>(&0b0010111, &0b00010, &imm).unwrap();
+        assert!(matches!(result, ParsedInstruction32::auipc { .. }));
     }
 
     #[test]
     fn test_parse_utype32_invalid_opcode() {
         let imm = 1 << 12;
-        let result = parse_utype32(&0b0000000, &0b00010, &imm);
+        let result = parse_utype32::<NumberedRegister>(&0b0000000, &0b00010, &imm);
         assert!(result.is_err());
-        assert_eq!(result.err(), Some(DisassemblerError::InvalidOpcode(0b0000000)));
+        assert_eq!(
+            result.err(),
+            Some(DisassemblerError::InvalidOpcode(0b0000000))
+        );
     }
 }

--- a/src/parser/utype.rs
+++ b/src/parser/utype.rs
@@ -7,7 +7,7 @@ pub(crate) fn parse_utype32<T: Register>(
     rd: &u8,
     imm: &i32,
 ) -> Result<ParsedInstruction32, DisassemblerError> {
-    let rd = T::from_u8(*rd)?.as_str();
+    let rd = T::try_from_u8(*rd)?.as_str();
 
     match opcode {
         0b0110111 => Ok(ParsedInstruction32::lui(lui { rd, imm: *imm })),

--- a/src/parser/utype.rs
+++ b/src/parser/utype.rs
@@ -7,7 +7,7 @@ pub(crate) fn parse_utype32<T: Register>(
     rd: &u8,
     imm: &i32,
 ) -> Result<ParsedInstruction32, DisassemblerError> {
-    let rd = T::from_u8(*rd)?.as_string();
+    let rd = T::from_u8(*rd)?.as_str();
 
     match opcode {
         0b0110111 => Ok(ParsedInstruction32::lui(lui { rd, imm: *imm })),

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -6,7 +6,7 @@ pub trait Register {
     fn from_u8(value: u8) -> Result<Self, DisassemblerError>
     where
         Self: Sized;
-    fn as_string(&self) -> String;
+    fn as_str(&self) -> &'static str;
 }
 
 impl Register for NumberedRegister {
@@ -18,8 +18,41 @@ impl Register for NumberedRegister {
         NumberedRegister::try_from(value)
     }
 
-    fn as_string(&self) -> String {
-        format!("x{}", *self as u8)
+    fn as_str(&self) -> &'static str {
+        match self {
+            NumberedRegister::x0 => "x0",
+            NumberedRegister::x1 => "x1",
+            NumberedRegister::x2 => "x2",
+            NumberedRegister::x3 => "x3",
+            NumberedRegister::x4 => "x4",
+            NumberedRegister::x5 => "x5",
+            NumberedRegister::x6 => "x6",
+            NumberedRegister::x7 => "x7",
+            NumberedRegister::x8 => "x8",
+            NumberedRegister::x9 => "x9",
+            NumberedRegister::x10 => "x10",
+            NumberedRegister::x11 => "x11",
+            NumberedRegister::x12 => "x12",
+            NumberedRegister::x13 => "x13",
+            NumberedRegister::x14 => "x14",
+            NumberedRegister::x15 => "x15",
+            NumberedRegister::x16 => "x16",
+            NumberedRegister::x17 => "x17",
+            NumberedRegister::x18 => "x18",
+            NumberedRegister::x19 => "x19",
+            NumberedRegister::x20 => "x20",
+            NumberedRegister::x21 => "x21",
+            NumberedRegister::x22 => "x22",
+            NumberedRegister::x23 => "x23",
+            NumberedRegister::x24 => "x24",
+            NumberedRegister::x25 => "x25",
+            NumberedRegister::x26 => "x26",
+            NumberedRegister::x27 => "x27",
+            NumberedRegister::x28 => "x28",
+            NumberedRegister::x29 => "x29",
+            NumberedRegister::x30 => "x30",
+            NumberedRegister::x31 => "x31",
+        }
     }
 }
 
@@ -32,40 +65,40 @@ impl Register for ABIRegister {
         ABIRegister::try_from(value)
     }
 
-    fn as_string(&self) -> String {
+    fn as_str(&self) -> &'static str {
         match self {
-            ABIRegister::zero => "zero".to_string(),
-            ABIRegister::ra => "ra".to_string(),
-            ABIRegister::sp => "sp".to_string(),
-            ABIRegister::gp => "gp".to_string(),
-            ABIRegister::tp => "tp".to_string(),
-            ABIRegister::t0 => "t0".to_string(),
-            ABIRegister::t1 => "t1".to_string(),
-            ABIRegister::t2 => "t2".to_string(),
-            ABIRegister::s0 => "s0".to_string(),
-            ABIRegister::s1 => "s1".to_string(),
-            ABIRegister::a0 => "a0".to_string(),
-            ABIRegister::a1 => "a1".to_string(),
-            ABIRegister::a2 => "a2".to_string(),
-            ABIRegister::a3 => "a3".to_string(),
-            ABIRegister::a4 => "a4".to_string(),
-            ABIRegister::a5 => "a5".to_string(),
-            ABIRegister::a6 => "a6".to_string(),
-            ABIRegister::a7 => "a7".to_string(),
-            ABIRegister::s2 => "s2".to_string(),
-            ABIRegister::s3 => "s3".to_string(),
-            ABIRegister::s4 => "s4".to_string(),
-            ABIRegister::s5 => "s5".to_string(),
-            ABIRegister::s6 => "s6".to_string(),
-            ABIRegister::s7 => "s7".to_string(),
-            ABIRegister::s8 => "s8".to_string(),
-            ABIRegister::s9 => "s9".to_string(),
-            ABIRegister::s10 => "s10".to_string(),
-            ABIRegister::s11 => "s11".to_string(),
-            ABIRegister::t3 => "t3".to_string(),
-            ABIRegister::t4 => "t4".to_string(),
-            ABIRegister::t5 => "t5".to_string(),
-            ABIRegister::t6 => "t6".to_string(),
+            ABIRegister::zero => "zero",
+            ABIRegister::ra => "ra",
+            ABIRegister::sp => "sp",
+            ABIRegister::gp => "gp",
+            ABIRegister::tp => "tp",
+            ABIRegister::t0 => "t0",
+            ABIRegister::t1 => "t1",
+            ABIRegister::t2 => "t2",
+            ABIRegister::s0 => "s0",
+            ABIRegister::s1 => "s1",
+            ABIRegister::a0 => "a0",
+            ABIRegister::a1 => "a1",
+            ABIRegister::a2 => "a2",
+            ABIRegister::a3 => "a3",
+            ABIRegister::a4 => "a4",
+            ABIRegister::a5 => "a5",
+            ABIRegister::a6 => "a6",
+            ABIRegister::a7 => "a7",
+            ABIRegister::s2 => "s2",
+            ABIRegister::s3 => "s3",
+            ABIRegister::s4 => "s4",
+            ABIRegister::s5 => "s5",
+            ABIRegister::s6 => "s6",
+            ABIRegister::s7 => "s7",
+            ABIRegister::s8 => "s8",
+            ABIRegister::s9 => "s9",
+            ABIRegister::s10 => "s10",
+            ABIRegister::s11 => "s11",
+            ABIRegister::t3 => "t3",
+            ABIRegister::t4 => "t4",
+            ABIRegister::t5 => "t5",
+            ABIRegister::t6 => "t6",
         }
     }
 }

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -1,10 +1,37 @@
 use crate::DisassemblerError;
 use std::fmt;
 
+pub trait Register {
+    fn as_u8(&self) -> u8;
+    fn from_u8(value: u8) -> Result<Self, DisassemblerError>
+    where
+        Self: Sized;
+}
+
+impl Register for NumberedRegister {
+    fn as_u8(&self) -> u8 {
+        *self as u8
+    }
+
+    fn from_u8(value: u8) -> Result<Self, DisassemblerError> {
+        NumberedRegister::try_from(value)
+    }
+}
+
+impl Register for ABIRegister {
+    fn as_u8(&self) -> u8 {
+        *self as u8
+    }
+
+    fn from_u8(value: u8) -> Result<Self, DisassemblerError> {
+        ABIRegister::try_from(value)
+    }
+}
+
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[repr(u8)]
 #[allow(non_camel_case_types)]
-pub enum Register {
+pub enum NumberedRegister {
     x0 = 0,
     x1 = 1,
     x2 = 2,
@@ -77,43 +104,43 @@ pub enum ABIRegister {
     t6 = 31,
 }
 
-impl TryFrom<u8> for Register {
+impl TryFrom<u8> for NumberedRegister {
     type Error = DisassemblerError;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(Register::x0),
-            1 => Ok(Register::x1),
-            2 => Ok(Register::x2),
-            3 => Ok(Register::x3),
-            4 => Ok(Register::x4),
-            5 => Ok(Register::x5),
-            6 => Ok(Register::x6),
-            7 => Ok(Register::x7),
-            8 => Ok(Register::x8),
-            9 => Ok(Register::x9),
-            10 => Ok(Register::x10),
-            11 => Ok(Register::x11),
-            12 => Ok(Register::x12),
-            13 => Ok(Register::x13),
-            14 => Ok(Register::x14),
-            15 => Ok(Register::x15),
-            16 => Ok(Register::x16),
-            17 => Ok(Register::x17),
-            18 => Ok(Register::x18),
-            19 => Ok(Register::x19),
-            20 => Ok(Register::x20),
-            21 => Ok(Register::x21),
-            22 => Ok(Register::x22),
-            23 => Ok(Register::x23),
-            24 => Ok(Register::x24),
-            25 => Ok(Register::x25),
-            26 => Ok(Register::x26),
-            27 => Ok(Register::x27),
-            28 => Ok(Register::x28),
-            29 => Ok(Register::x29),
-            30 => Ok(Register::x30),
-            31 => Ok(Register::x31),
+            0 => Ok(NumberedRegister::x0),
+            1 => Ok(NumberedRegister::x1),
+            2 => Ok(NumberedRegister::x2),
+            3 => Ok(NumberedRegister::x3),
+            4 => Ok(NumberedRegister::x4),
+            5 => Ok(NumberedRegister::x5),
+            6 => Ok(NumberedRegister::x6),
+            7 => Ok(NumberedRegister::x7),
+            8 => Ok(NumberedRegister::x8),
+            9 => Ok(NumberedRegister::x9),
+            10 => Ok(NumberedRegister::x10),
+            11 => Ok(NumberedRegister::x11),
+            12 => Ok(NumberedRegister::x12),
+            13 => Ok(NumberedRegister::x13),
+            14 => Ok(NumberedRegister::x14),
+            15 => Ok(NumberedRegister::x15),
+            16 => Ok(NumberedRegister::x16),
+            17 => Ok(NumberedRegister::x17),
+            18 => Ok(NumberedRegister::x18),
+            19 => Ok(NumberedRegister::x19),
+            20 => Ok(NumberedRegister::x20),
+            21 => Ok(NumberedRegister::x21),
+            22 => Ok(NumberedRegister::x22),
+            23 => Ok(NumberedRegister::x23),
+            24 => Ok(NumberedRegister::x24),
+            25 => Ok(NumberedRegister::x25),
+            26 => Ok(NumberedRegister::x26),
+            27 => Ok(NumberedRegister::x27),
+            28 => Ok(NumberedRegister::x28),
+            29 => Ok(NumberedRegister::x29),
+            30 => Ok(NumberedRegister::x30),
+            31 => Ok(NumberedRegister::x31),
             _ => Err(DisassemblerError::InvalidRegister(value)),
         }
     }
@@ -161,7 +188,7 @@ impl TryFrom<u8> for ABIRegister {
     }
 }
 
-impl fmt::Display for Register {
+impl fmt::Display for NumberedRegister {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "x{}", *self as u8)
     }
@@ -212,38 +239,38 @@ mod tests {
 
     #[test]
     fn test_try_from_register() {
-        assert_eq!(0.try_into(), Ok(Register::x0));
-        assert_eq!(1.try_into(), Ok(Register::x1));
-        assert_eq!(2.try_into(), Ok(Register::x2));
-        assert_eq!(3.try_into(), Ok(Register::x3));
-        assert_eq!(4.try_into(), Ok(Register::x4));
-        assert_eq!(5.try_into(), Ok(Register::x5));
-        assert_eq!(6.try_into(), Ok(Register::x6));
-        assert_eq!(7.try_into(), Ok(Register::x7));
-        assert_eq!(8.try_into(), Ok(Register::x8));
-        assert_eq!(9.try_into(), Ok(Register::x9));
-        assert_eq!(10.try_into(), Ok(Register::x10));
-        assert_eq!(11.try_into(), Ok(Register::x11));
-        assert_eq!(12.try_into(), Ok(Register::x12));
-        assert_eq!(13.try_into(), Ok(Register::x13));
-        assert_eq!(14.try_into(), Ok(Register::x14));
-        assert_eq!(15.try_into(), Ok(Register::x15));
-        assert_eq!(16.try_into(), Ok(Register::x16));
-        assert_eq!(17.try_into(), Ok(Register::x17));
-        assert_eq!(18.try_into(), Ok(Register::x18));
-        assert_eq!(19.try_into(), Ok(Register::x19));
-        assert_eq!(20.try_into(), Ok(Register::x20));
-        assert_eq!(21.try_into(), Ok(Register::x21));
-        assert_eq!(22.try_into(), Ok(Register::x22));
-        assert_eq!(23.try_into(), Ok(Register::x23));
-        assert_eq!(24.try_into(), Ok(Register::x24));
-        assert_eq!(25.try_into(), Ok(Register::x25));
-        assert_eq!(26.try_into(), Ok(Register::x26));
-        assert_eq!(27.try_into(), Ok(Register::x27));
-        assert_eq!(28.try_into(), Ok(Register::x28));
-        assert_eq!(29.try_into(), Ok(Register::x29));
-        assert_eq!(30.try_into(), Ok(Register::x30));
-        assert_eq!(31.try_into(), Ok(Register::x31));
+        assert_eq!(0.try_into(), Ok(NumberedRegister::x0));
+        assert_eq!(1.try_into(), Ok(NumberedRegister::x1));
+        assert_eq!(2.try_into(), Ok(NumberedRegister::x2));
+        assert_eq!(3.try_into(), Ok(NumberedRegister::x3));
+        assert_eq!(4.try_into(), Ok(NumberedRegister::x4));
+        assert_eq!(5.try_into(), Ok(NumberedRegister::x5));
+        assert_eq!(6.try_into(), Ok(NumberedRegister::x6));
+        assert_eq!(7.try_into(), Ok(NumberedRegister::x7));
+        assert_eq!(8.try_into(), Ok(NumberedRegister::x8));
+        assert_eq!(9.try_into(), Ok(NumberedRegister::x9));
+        assert_eq!(10.try_into(), Ok(NumberedRegister::x10));
+        assert_eq!(11.try_into(), Ok(NumberedRegister::x11));
+        assert_eq!(12.try_into(), Ok(NumberedRegister::x12));
+        assert_eq!(13.try_into(), Ok(NumberedRegister::x13));
+        assert_eq!(14.try_into(), Ok(NumberedRegister::x14));
+        assert_eq!(15.try_into(), Ok(NumberedRegister::x15));
+        assert_eq!(16.try_into(), Ok(NumberedRegister::x16));
+        assert_eq!(17.try_into(), Ok(NumberedRegister::x17));
+        assert_eq!(18.try_into(), Ok(NumberedRegister::x18));
+        assert_eq!(19.try_into(), Ok(NumberedRegister::x19));
+        assert_eq!(20.try_into(), Ok(NumberedRegister::x20));
+        assert_eq!(21.try_into(), Ok(NumberedRegister::x21));
+        assert_eq!(22.try_into(), Ok(NumberedRegister::x22));
+        assert_eq!(23.try_into(), Ok(NumberedRegister::x23));
+        assert_eq!(24.try_into(), Ok(NumberedRegister::x24));
+        assert_eq!(25.try_into(), Ok(NumberedRegister::x25));
+        assert_eq!(26.try_into(), Ok(NumberedRegister::x26));
+        assert_eq!(27.try_into(), Ok(NumberedRegister::x27));
+        assert_eq!(28.try_into(), Ok(NumberedRegister::x28));
+        assert_eq!(29.try_into(), Ok(NumberedRegister::x29));
+        assert_eq!(30.try_into(), Ok(NumberedRegister::x30));
+        assert_eq!(31.try_into(), Ok(NumberedRegister::x31));
     }
 
     #[test]
@@ -282,4 +309,3 @@ mod tests {
         assert_eq!(31.try_into(), Ok(ABIRegister::t6));
     }
 }
-

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use crate::DisassemblerError;
+use std::fmt;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[repr(u8)]
@@ -37,6 +37,44 @@ pub enum Register {
     x29 = 29,
     x30 = 30,
     x31 = 31,
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+#[repr(u8)]
+#[allow(non_camel_case_types)]
+pub enum ABIRegister {
+    zero = 0,
+    ra = 1,
+    sp = 2,
+    gp = 3,
+    tp = 4,
+    t0 = 5,
+    t1 = 6,
+    t2 = 7,
+    s0 = 8,
+    s1 = 9,
+    a0 = 10,
+    a1 = 11,
+    a2 = 12,
+    a3 = 13,
+    a4 = 14,
+    a5 = 15,
+    a6 = 16,
+    a7 = 17,
+    s2 = 18,
+    s3 = 19,
+    s4 = 20,
+    s5 = 21,
+    s6 = 22,
+    s7 = 23,
+    s8 = 24,
+    s9 = 25,
+    s10 = 26,
+    s11 = 27,
+    t3 = 28,
+    t4 = 29,
+    t5 = 30,
+    t6 = 31,
 }
 
 impl TryFrom<u8> for Register {
@@ -81,9 +119,90 @@ impl TryFrom<u8> for Register {
     }
 }
 
+impl TryFrom<u8> for ABIRegister {
+    type Error = DisassemblerError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(ABIRegister::zero),
+            1 => Ok(ABIRegister::ra),
+            2 => Ok(ABIRegister::sp),
+            3 => Ok(ABIRegister::gp),
+            4 => Ok(ABIRegister::tp),
+            5 => Ok(ABIRegister::t0),
+            6 => Ok(ABIRegister::t1),
+            7 => Ok(ABIRegister::t2),
+            8 => Ok(ABIRegister::s0),
+            9 => Ok(ABIRegister::s1),
+            10 => Ok(ABIRegister::a0),
+            11 => Ok(ABIRegister::a1),
+            12 => Ok(ABIRegister::a2),
+            13 => Ok(ABIRegister::a3),
+            14 => Ok(ABIRegister::a4),
+            15 => Ok(ABIRegister::a5),
+            16 => Ok(ABIRegister::a6),
+            17 => Ok(ABIRegister::a7),
+            18 => Ok(ABIRegister::s2),
+            19 => Ok(ABIRegister::s3),
+            20 => Ok(ABIRegister::s4),
+            21 => Ok(ABIRegister::s5),
+            22 => Ok(ABIRegister::s6),
+            23 => Ok(ABIRegister::s7),
+            24 => Ok(ABIRegister::s8),
+            25 => Ok(ABIRegister::s9),
+            26 => Ok(ABIRegister::s10),
+            27 => Ok(ABIRegister::s11),
+            28 => Ok(ABIRegister::t3),
+            29 => Ok(ABIRegister::t4),
+            30 => Ok(ABIRegister::t5),
+            31 => Ok(ABIRegister::t6),
+            _ => Err(DisassemblerError::InvalidRegister(value)),
+        }
+    }
+}
+
 impl fmt::Display for Register {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "x{}", *self as u8)
+    }
+}
+
+impl fmt::Display for ABIRegister {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ABIRegister::zero => write!(f, "zero"),
+            ABIRegister::ra => write!(f, "ra"),
+            ABIRegister::sp => write!(f, "sp"),
+            ABIRegister::gp => write!(f, "gp"),
+            ABIRegister::tp => write!(f, "tp"),
+            ABIRegister::t0 => write!(f, "t0"),
+            ABIRegister::t1 => write!(f, "t1"),
+            ABIRegister::t2 => write!(f, "t2"),
+            ABIRegister::s0 => write!(f, "s0"),
+            ABIRegister::s1 => write!(f, "s1"),
+            ABIRegister::a0 => write!(f, "a0"),
+            ABIRegister::a1 => write!(f, "a1"),
+            ABIRegister::a2 => write!(f, "a2"),
+            ABIRegister::a3 => write!(f, "a3"),
+            ABIRegister::a4 => write!(f, "a4"),
+            ABIRegister::a5 => write!(f, "a5"),
+            ABIRegister::a6 => write!(f, "a6"),
+            ABIRegister::a7 => write!(f, "a7"),
+            ABIRegister::s2 => write!(f, "s2"),
+            ABIRegister::s3 => write!(f, "s3"),
+            ABIRegister::s4 => write!(f, "s4"),
+            ABIRegister::s5 => write!(f, "s5"),
+            ABIRegister::s6 => write!(f, "s6"),
+            ABIRegister::s7 => write!(f, "s7"),
+            ABIRegister::s8 => write!(f, "s8"),
+            ABIRegister::s9 => write!(f, "s9"),
+            ABIRegister::s10 => write!(f, "s10"),
+            ABIRegister::s11 => write!(f, "s11"),
+            ABIRegister::t3 => write!(f, "t3"),
+            ABIRegister::t4 => write!(f, "t4"),
+            ABIRegister::t5 => write!(f, "t5"),
+            ABIRegister::t6 => write!(f, "t6"),
+        }
     }
 }
 
@@ -126,4 +245,41 @@ mod tests {
         assert_eq!(30.try_into(), Ok(Register::x30));
         assert_eq!(31.try_into(), Ok(Register::x31));
     }
+
+    #[test]
+    fn test_try_from_abi_register() {
+        assert_eq!(0.try_into(), Ok(ABIRegister::zero));
+        assert_eq!(1.try_into(), Ok(ABIRegister::ra));
+        assert_eq!(2.try_into(), Ok(ABIRegister::sp));
+        assert_eq!(3.try_into(), Ok(ABIRegister::gp));
+        assert_eq!(4.try_into(), Ok(ABIRegister::tp));
+        assert_eq!(5.try_into(), Ok(ABIRegister::t0));
+        assert_eq!(6.try_into(), Ok(ABIRegister::t1));
+        assert_eq!(7.try_into(), Ok(ABIRegister::t2));
+        assert_eq!(8.try_into(), Ok(ABIRegister::s0));
+        assert_eq!(9.try_into(), Ok(ABIRegister::s1));
+        assert_eq!(10.try_into(), Ok(ABIRegister::a0));
+        assert_eq!(11.try_into(), Ok(ABIRegister::a1));
+        assert_eq!(12.try_into(), Ok(ABIRegister::a2));
+        assert_eq!(13.try_into(), Ok(ABIRegister::a3));
+        assert_eq!(14.try_into(), Ok(ABIRegister::a4));
+        assert_eq!(15.try_into(), Ok(ABIRegister::a5));
+        assert_eq!(16.try_into(), Ok(ABIRegister::a6));
+        assert_eq!(17.try_into(), Ok(ABIRegister::a7));
+        assert_eq!(18.try_into(), Ok(ABIRegister::s2));
+        assert_eq!(19.try_into(), Ok(ABIRegister::s3));
+        assert_eq!(20.try_into(), Ok(ABIRegister::s4));
+        assert_eq!(21.try_into(), Ok(ABIRegister::s5));
+        assert_eq!(22.try_into(), Ok(ABIRegister::s6));
+        assert_eq!(23.try_into(), Ok(ABIRegister::s7));
+        assert_eq!(24.try_into(), Ok(ABIRegister::s8));
+        assert_eq!(25.try_into(), Ok(ABIRegister::s9));
+        assert_eq!(26.try_into(), Ok(ABIRegister::s10));
+        assert_eq!(27.try_into(), Ok(ABIRegister::s11));
+        assert_eq!(28.try_into(), Ok(ABIRegister::t3));
+        assert_eq!(29.try_into(), Ok(ABIRegister::t4));
+        assert_eq!(30.try_into(), Ok(ABIRegister::t5));
+        assert_eq!(31.try_into(), Ok(ABIRegister::t6));
+    }
 }
+

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 pub trait Register {
     fn as_u8(&self) -> u8;
-    fn from_u8(value: u8) -> Result<Self, DisassemblerError>
+    fn try_from_u8(value: u8) -> Result<Self, DisassemblerError>
     where
         Self: Sized;
     fn as_str(&self) -> &'static str;
@@ -14,7 +14,7 @@ impl Register for NumberedRegister {
         *self as u8
     }
 
-    fn from_u8(value: u8) -> Result<Self, DisassemblerError> {
+    fn try_from_u8(value: u8) -> Result<Self, DisassemblerError> {
         NumberedRegister::try_from(value)
     }
 
@@ -61,7 +61,7 @@ impl Register for ABIRegister {
         *self as u8
     }
 
-    fn from_u8(value: u8) -> Result<Self, DisassemblerError> {
+    fn try_from_u8(value: u8) -> Result<Self, DisassemblerError> {
         ABIRegister::try_from(value)
     }
 

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -6,6 +6,7 @@ pub trait Register {
     fn from_u8(value: u8) -> Result<Self, DisassemblerError>
     where
         Self: Sized;
+    fn as_string(&self) -> String;
 }
 
 impl Register for NumberedRegister {
@@ -16,6 +17,10 @@ impl Register for NumberedRegister {
     fn from_u8(value: u8) -> Result<Self, DisassemblerError> {
         NumberedRegister::try_from(value)
     }
+
+    fn as_string(&self) -> String {
+        format!("x{}", *self as u8)
+    }
 }
 
 impl Register for ABIRegister {
@@ -25,6 +30,43 @@ impl Register for ABIRegister {
 
     fn from_u8(value: u8) -> Result<Self, DisassemblerError> {
         ABIRegister::try_from(value)
+    }
+
+    fn as_string(&self) -> String {
+        match self {
+            ABIRegister::zero => "zero".to_string(),
+            ABIRegister::ra => "ra".to_string(),
+            ABIRegister::sp => "sp".to_string(),
+            ABIRegister::gp => "gp".to_string(),
+            ABIRegister::tp => "tp".to_string(),
+            ABIRegister::t0 => "t0".to_string(),
+            ABIRegister::t1 => "t1".to_string(),
+            ABIRegister::t2 => "t2".to_string(),
+            ABIRegister::s0 => "s0".to_string(),
+            ABIRegister::s1 => "s1".to_string(),
+            ABIRegister::a0 => "a0".to_string(),
+            ABIRegister::a1 => "a1".to_string(),
+            ABIRegister::a2 => "a2".to_string(),
+            ABIRegister::a3 => "a3".to_string(),
+            ABIRegister::a4 => "a4".to_string(),
+            ABIRegister::a5 => "a5".to_string(),
+            ABIRegister::a6 => "a6".to_string(),
+            ABIRegister::a7 => "a7".to_string(),
+            ABIRegister::s2 => "s2".to_string(),
+            ABIRegister::s3 => "s3".to_string(),
+            ABIRegister::s4 => "s4".to_string(),
+            ABIRegister::s5 => "s5".to_string(),
+            ABIRegister::s6 => "s6".to_string(),
+            ABIRegister::s7 => "s7".to_string(),
+            ABIRegister::s8 => "s8".to_string(),
+            ABIRegister::s9 => "s9".to_string(),
+            ABIRegister::s10 => "s10".to_string(),
+            ABIRegister::s11 => "s11".to_string(),
+            ABIRegister::t3 => "t3".to_string(),
+            ABIRegister::t4 => "t4".to_string(),
+            ABIRegister::t5 => "t5".to_string(),
+            ABIRegister::t6 => "t6".to_string(),
+        }
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -10,153 +10,153 @@ mod tests {
             (
                 0x00B50533,
                 ParsedInstruction32::add(add {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
-                    rs2: "x11".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
+                    rs2: "x11",
                 }),
             ),
             (
                 0x40B50533,
                 ParsedInstruction32::sub(sub {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
-                    rs2: "x11".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
+                    rs2: "x11",
                 }),
             ),
             (
                 0x00B52533,
                 ParsedInstruction32::slt(slt {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
-                    rs2: "x11".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
+                    rs2: "x11",
                 }),
             ),
             (
                 0x00B53533,
                 ParsedInstruction32::sltu(sltu {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
-                    rs2: "x11".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
+                    rs2: "x11",
                 }),
             ),
             (
                 0x00B54533,
                 ParsedInstruction32::xor(xor {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
-                    rs2: "x11".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
+                    rs2: "x11",
                 }),
             ),
             (
                 0x00B56533,
                 ParsedInstruction32::or(or {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
-                    rs2: "x11".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
+                    rs2: "x11",
                 }),
             ),
             (
                 0x00B57533,
                 ParsedInstruction32::and(and {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
-                    rs2: "x11".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
+                    rs2: "x11",
                 }),
             ),
             (
                 0x00B55533,
                 ParsedInstruction32::srl(srl {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
-                    rs2: "x11".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
+                    rs2: "x11",
                 }),
             ),
             (
                 0x40B55533,
                 ParsedInstruction32::sra(sra {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
-                    rs2: "x11".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
+                    rs2: "x11",
                 }),
             ),
             (
                 0x00B51533,
                 ParsedInstruction32::sll(sll {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
-                    rs2: "x11".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
+                    rs2: "x11",
                 }),
             ),
             // I-type instructions
             (
                 0x00A50513,
                 ParsedInstruction32::addi(addi {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
                     imm: 10,
                 }),
             ),
             (
                 0x00A52513,
                 ParsedInstruction32::slti(slti {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
                     imm: 10,
                 }),
             ),
             (
                 0x00A53513,
                 ParsedInstruction32::sltiu(sltiu {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
                     imm: 10,
                 }),
             ),
             (
                 0x00A54513,
                 ParsedInstruction32::xori(xori {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
                     imm: 10,
                 }),
             ),
             (
                 0x00A56513,
                 ParsedInstruction32::ori(ori {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
                     imm: 10,
                 }),
             ),
             (
                 0x00A57513,
                 ParsedInstruction32::andi(andi {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
                     imm: 10,
                 }),
             ),
             (
                 0x00451513,
                 ParsedInstruction32::slli(slli {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
                     shamt: 4,
                 }),
             ),
             (
                 0x00455513,
                 ParsedInstruction32::srli(srli {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
                     shamt: 4,
                 }),
             ),
             (
                 0x40455513,
                 ParsedInstruction32::srai(srai {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
                     shamt: 4,
                 }),
             ),
@@ -164,40 +164,40 @@ mod tests {
             (
                 0x00A50503,
                 ParsedInstruction32::lb(lb {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
                     imm: 10,
                 }),
             ),
             (
                 0x00A51503,
                 ParsedInstruction32::lh(lh {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
                     imm: 10,
                 }),
             ),
             (
                 0x00A52503,
                 ParsedInstruction32::lw(lw {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
                     imm: 10,
                 }),
             ),
             (
                 0x00A54503,
                 ParsedInstruction32::lbu(lbu {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
                     imm: 10,
                 }),
             ),
             (
                 0x00A55503,
                 ParsedInstruction32::lhu(lhu {
-                    rd: "x10".to_string(),
-                    rs1: "x10".to_string(),
+                    rd: "x10",
+                    rs1: "x10",
                     imm: 10,
                 }),
             ),
@@ -205,24 +205,24 @@ mod tests {
             (
                 0x00A50523,
                 ParsedInstruction32::sb(sb {
-                    rs1: "x10".to_string(),
-                    rs2: "x10".to_string(),
+                    rs1: "x10",
+                    rs2: "x10",
                     imm: 10,
                 }),
             ),
             (
                 0x00A51523,
                 ParsedInstruction32::sh(sh {
-                    rs1: "x10".to_string(),
-                    rs2: "x10".to_string(),
+                    rs1: "x10",
+                    rs2: "x10",
                     imm: 10,
                 }),
             ),
             (
                 0x00A52523,
                 ParsedInstruction32::sw(sw {
-                    rs1: "x10".to_string(),
-                    rs2: "x10".to_string(),
+                    rs1: "x10",
+                    rs2: "x10",
                     imm: 10,
                 }),
             ),
@@ -230,71 +230,68 @@ mod tests {
             (
                 0x00a50563,
                 ParsedInstruction32::beq(beq {
-                    rs1: "x10".to_string(),
-                    rs2: "x10".to_string(),
+                    rs1: "x10",
+                    rs2: "x10",
                     imm: 10,
                 }),
             ),
             (
                 0x00a51563,
                 ParsedInstruction32::bne(bne {
-                    rs1: "x10".to_string(),
-                    rs2: "x10".to_string(),
+                    rs1: "x10",
+                    rs2: "x10",
                     imm: 10,
                 }),
             ),
             (
                 0x00a54563,
                 ParsedInstruction32::blt(blt {
-                    rs1: "x10".to_string(),
-                    rs2: "x10".to_string(),
+                    rs1: "x10",
+                    rs2: "x10",
                     imm: 10,
                 }),
             ),
             (
                 0x00a55563,
                 ParsedInstruction32::bge(bge {
-                    rs1: "x10".to_string(),
-                    rs2: "x10".to_string(),
+                    rs1: "x10",
+                    rs2: "x10",
                     imm: 10,
                 }),
             ),
             (
                 0x00a56563,
                 ParsedInstruction32::bltu(bltu {
-                    rs1: "x10".to_string(),
-                    rs2: "x10".to_string(),
+                    rs1: "x10",
+                    rs2: "x10",
                     imm: 10,
                 }),
             ),
             (
                 0x00a57563,
                 ParsedInstruction32::bgeu(bgeu {
-                    rs1: "x10".to_string(),
-                    rs2: "x10".to_string(),
+                    rs1: "x10",
+                    rs2: "x10",
                     imm: 10,
                 }),
             ),
             // J-type instruction
             (
                 0x010000EF,
-                ParsedInstruction32::jal(jal {
-                    rd: "x1".to_string(),
-                    imm: 16,
-                }),
+                ParsedInstruction32::jal(jal { rd: "x1", imm: 16 }),
             ),
             // U-type instructions
             (
                 0x000100b7,
                 ParsedInstruction32::lui(lui {
-                    rd: "x1".to_string(),
+                    rd: "x1",
                     imm: 16 << 12,
                 }),
             ),
             (
                 0x00010097,
                 ParsedInstruction32::auipc(auipc {
-                    rd: "x1".to_string(),
+                    rd: "x1",
                     imm: 16 << 12,
                 }),
             ),
@@ -302,8 +299,8 @@ mod tests {
             (
                 0x00A500E7,
                 ParsedInstruction32::jalr(jalr {
-                    rd: "x1".to_string(),
-                    rs1: "x10".to_string(),
+                    rd: "x1",
+                    rs1: "x10",
                     imm: 10,
                 }),
             ),
@@ -335,153 +332,153 @@ mod tests {
             (
                 0x00B50533,
                 ParsedInstruction32::add(add {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
-                    rs2: "a1".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
+                    rs2: "a1",
                 }),
             ),
             (
                 0x40B50533,
                 ParsedInstruction32::sub(sub {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
-                    rs2: "a1".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
+                    rs2: "a1",
                 }),
             ),
             (
                 0x00B52533,
                 ParsedInstruction32::slt(slt {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
-                    rs2: "a1".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
+                    rs2: "a1",
                 }),
             ),
             (
                 0x00B53533,
                 ParsedInstruction32::sltu(sltu {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
-                    rs2: "a1".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
+                    rs2: "a1",
                 }),
             ),
             (
                 0x00B54533,
                 ParsedInstruction32::xor(xor {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
-                    rs2: "a1".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
+                    rs2: "a1",
                 }),
             ),
             (
                 0x00B56533,
                 ParsedInstruction32::or(or {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
-                    rs2: "a1".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
+                    rs2: "a1",
                 }),
             ),
             (
                 0x00B57533,
                 ParsedInstruction32::and(and {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
-                    rs2: "a1".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
+                    rs2: "a1",
                 }),
             ),
             (
                 0x00B55533,
                 ParsedInstruction32::srl(srl {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
-                    rs2: "a1".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
+                    rs2: "a1",
                 }),
             ),
             (
                 0x40B55533,
                 ParsedInstruction32::sra(sra {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
-                    rs2: "a1".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
+                    rs2: "a1",
                 }),
             ),
             (
                 0x00B51533,
                 ParsedInstruction32::sll(sll {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
-                    rs2: "a1".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
+                    rs2: "a1",
                 }),
             ),
             // I-type instructions
             (
                 0x00A50513,
                 ParsedInstruction32::addi(addi {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
                     imm: 10,
                 }),
             ),
             (
                 0x00A52513,
                 ParsedInstruction32::slti(slti {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
                     imm: 10,
                 }),
             ),
             (
                 0x00A53513,
                 ParsedInstruction32::sltiu(sltiu {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
                     imm: 10,
                 }),
             ),
             (
                 0x00A54513,
                 ParsedInstruction32::xori(xori {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
                     imm: 10,
                 }),
             ),
             (
                 0x00A56513,
                 ParsedInstruction32::ori(ori {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
                     imm: 10,
                 }),
             ),
             (
                 0x00A57513,
                 ParsedInstruction32::andi(andi {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
                     imm: 10,
                 }),
             ),
             (
                 0x00451513,
                 ParsedInstruction32::slli(slli {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
                     shamt: 4,
                 }),
             ),
             (
                 0x00455513,
                 ParsedInstruction32::srli(srli {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
                     shamt: 4,
                 }),
             ),
             (
                 0x40455513,
                 ParsedInstruction32::srai(srai {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
                     shamt: 4,
                 }),
             ),
@@ -489,40 +486,40 @@ mod tests {
             (
                 0x00A50503,
                 ParsedInstruction32::lb(lb {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
                     imm: 10,
                 }),
             ),
             (
                 0x00A51503,
                 ParsedInstruction32::lh(lh {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
                     imm: 10,
                 }),
             ),
             (
                 0x00A52503,
                 ParsedInstruction32::lw(lw {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
                     imm: 10,
                 }),
             ),
             (
                 0x00A54503,
                 ParsedInstruction32::lbu(lbu {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
                     imm: 10,
                 }),
             ),
             (
                 0x00A55503,
                 ParsedInstruction32::lhu(lhu {
-                    rd: "a0".to_string(),
-                    rs1: "a0".to_string(),
+                    rd: "a0",
+                    rs1: "a0",
                     imm: 10,
                 }),
             ),
@@ -530,24 +527,24 @@ mod tests {
             (
                 0x00A50523,
                 ParsedInstruction32::sb(sb {
-                    rs1: "a0".to_string(),
-                    rs2: "a0".to_string(),
+                    rs1: "a0",
+                    rs2: "a0",
                     imm: 10,
                 }),
             ),
             (
                 0x00A51523,
                 ParsedInstruction32::sh(sh {
-                    rs1: "a0".to_string(),
-                    rs2: "a0".to_string(),
+                    rs1: "a0",
+                    rs2: "a0",
                     imm: 10,
                 }),
             ),
             (
                 0x00A52523,
                 ParsedInstruction32::sw(sw {
-                    rs1: "a0".to_string(),
-                    rs2: "a0".to_string(),
+                    rs1: "a0",
+                    rs2: "a0",
                     imm: 10,
                 }),
             ),
@@ -555,71 +552,68 @@ mod tests {
             (
                 0x00a50563,
                 ParsedInstruction32::beq(beq {
-                    rs1: "a0".to_string(),
-                    rs2: "a0".to_string(),
+                    rs1: "a0",
+                    rs2: "a0",
                     imm: 10,
                 }),
             ),
             (
                 0x00a51563,
                 ParsedInstruction32::bne(bne {
-                    rs1: "a0".to_string(),
-                    rs2: "a0".to_string(),
+                    rs1: "a0",
+                    rs2: "a0",
                     imm: 10,
                 }),
             ),
             (
                 0x00a54563,
                 ParsedInstruction32::blt(blt {
-                    rs1: "a0".to_string(),
-                    rs2: "a0".to_string(),
+                    rs1: "a0",
+                    rs2: "a0",
                     imm: 10,
                 }),
             ),
             (
                 0x00a55563,
                 ParsedInstruction32::bge(bge {
-                    rs1: "a0".to_string(),
-                    rs2: "a0".to_string(),
+                    rs1: "a0",
+                    rs2: "a0",
                     imm: 10,
                 }),
             ),
             (
                 0x00a56563,
                 ParsedInstruction32::bltu(bltu {
-                    rs1: "a0".to_string(),
-                    rs2: "a0".to_string(),
+                    rs1: "a0",
+                    rs2: "a0",
                     imm: 10,
                 }),
             ),
             (
                 0x00a57563,
                 ParsedInstruction32::bgeu(bgeu {
-                    rs1: "a0".to_string(),
-                    rs2: "a0".to_string(),
+                    rs1: "a0",
+                    rs2: "a0",
                     imm: 10,
                 }),
             ),
             // J-type instruction
             (
                 0x010000EF,
-                ParsedInstruction32::jal(jal {
-                    rd: "ra".to_string(),
-                    imm: 16,
-                }),
+                ParsedInstruction32::jal(jal { rd: "ra", imm: 16 }),
             ),
             // U-type instructions
             (
                 0x000100b7,
                 ParsedInstruction32::lui(lui {
-                    rd: "ra".to_string(),
+                    rd: "ra",
                     imm: 16 << 12,
                 }),
             ),
             (
                 0x00010097,
                 ParsedInstruction32::auipc(auipc {
-                    rd: "ra".to_string(),
+                    rd: "ra",
                     imm: 16 << 12,
                 }),
             ),
@@ -627,8 +621,8 @@ mod tests {
             (
                 0x00A500E7,
                 ParsedInstruction32::jalr(jalr {
-                    rd: "ra".to_string(),
-                    rs1: "a0".to_string(),
+                    rd: "ra",
+                    rs1: "a0",
                     imm: 10,
                 }),
             ),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,74 +1,320 @@
 #[cfg(test)]
 mod tests {
     use risc_v_disassembler::parse;
-    use risc_v_disassembler::{
-        ParsedInstruction32,
-        parsed_instructions::*
-    };
     use risc_v_disassembler::Register;
+    use risc_v_disassembler::{parsed_instructions::*, ParsedInstruction32};
 
     /// Returns a vector of tuples containing (instruction hex, expected ParsedInstruction32) for RV32I instructions
     fn get_rv32i_be_test_cases() -> Vec<(u32, ParsedInstruction32)> {
         vec![
             // R-type instructions
-            (0x00B50533, ParsedInstruction32::add (add { rd: Register::x10, rs1: Register::x10, rs2: Register::x11 })),
-            (0x40B50533, ParsedInstruction32::sub (sub { rd: Register::x10, rs1: Register::x10, rs2: Register::x11 })),
-            (0x00B52533, ParsedInstruction32::slt (slt { rd: Register::x10, rs1: Register::x10, rs2: Register::x11 })),
-            (0x00B53533, ParsedInstruction32::sltu (sltu { rd: Register::x10, rs1: Register::x10, rs2: Register::x11 })),
-            (0x00B54533, ParsedInstruction32::xor (xor { rd: Register::x10, rs1: Register::x10, rs2: Register::x11 })),
-            (0x00B56533, ParsedInstruction32::or (or { rd: Register::x10, rs1: Register::x10, rs2: Register::x11 })),
-            (0x00B57533, ParsedInstruction32::and (and { rd: Register::x10, rs1: Register::x10, rs2: Register::x11 })),
-            (0x00B55533, ParsedInstruction32::srl (srl { rd: Register::x10, rs1: Register::x10, rs2: Register::x11 })),
-            (0x40B55533, ParsedInstruction32::sra (sra { rd: Register::x10, rs1: Register::x10, rs2: Register::x11 })),
-            (0x00B51533, ParsedInstruction32::sll (sll { rd: Register::x10, rs1: Register::x10, rs2: Register::x11 })),
-
+            (
+                0x00B50533,
+                ParsedInstruction32::add(add {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    rs2: "x11".to_string(),
+                }),
+            ),
+            (
+                0x40B50533,
+                ParsedInstruction32::sub(sub {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    rs2: "x11".to_string(),
+                }),
+            ),
+            (
+                0x00B52533,
+                ParsedInstruction32::slt(slt {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    rs2: "x11".to_string(),
+                }),
+            ),
+            (
+                0x00B53533,
+                ParsedInstruction32::sltu(sltu {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    rs2: "x11".to_string(),
+                }),
+            ),
+            (
+                0x00B54533,
+                ParsedInstruction32::xor(xor {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    rs2: "x11".to_string(),
+                }),
+            ),
+            (
+                0x00B56533,
+                ParsedInstruction32::or(or {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    rs2: "x11".to_string(),
+                }),
+            ),
+            (
+                0x00B57533,
+                ParsedInstruction32::and(and {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    rs2: "x11".to_string(),
+                }),
+            ),
+            (
+                0x00B55533,
+                ParsedInstruction32::srl(srl {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    rs2: "x11".to_string(),
+                }),
+            ),
+            (
+                0x40B55533,
+                ParsedInstruction32::sra(sra {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    rs2: "x11".to_string(),
+                }),
+            ),
+            (
+                0x00B51533,
+                ParsedInstruction32::sll(sll {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    rs2: "x11".to_string(),
+                }),
+            ),
             // I-type instructions
-            (0x00A50513, ParsedInstruction32::addi (addi { rd: Register::x10, rs1: Register::x10, imm: 10 })),
-            (0x00A52513, ParsedInstruction32::slti (slti { rd: Register::x10, rs1: Register::x10, imm: 10 })),
-            (0x00A53513, ParsedInstruction32::sltiu (sltiu { rd: Register::x10, rs1: Register::x10, imm: 10 })),
-            (0x00A54513, ParsedInstruction32::xori (xori { rd: Register::x10, rs1: Register::x10, imm: 10 })),
-            (0x00A56513, ParsedInstruction32::ori (ori { rd: Register::x10, rs1: Register::x10, imm: 10 })),
-            (0x00A57513, ParsedInstruction32::andi (andi { rd: Register::x10, rs1: Register::x10, imm: 10 })),
-            (0x00451513, ParsedInstruction32::slli (slli { rd: Register::x10, rs1: Register::x10, shamt: 4 })),
-            (0x00455513, ParsedInstruction32::srli (srli { rd: Register::x10, rs1: Register::x10, shamt: 4 })),
-            (0x40455513, ParsedInstruction32::srai (srai { rd: Register::x10, rs1: Register::x10, shamt: 4 })),
-
+            (
+                0x00A50513,
+                ParsedInstruction32::addi(addi {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A52513,
+                ParsedInstruction32::slti(slti {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A53513,
+                ParsedInstruction32::sltiu(sltiu {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A54513,
+                ParsedInstruction32::xori(xori {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A56513,
+                ParsedInstruction32::ori(ori {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A57513,
+                ParsedInstruction32::andi(andi {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00451513,
+                ParsedInstruction32::slli(slli {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    shamt: 4,
+                }),
+            ),
+            (
+                0x00455513,
+                ParsedInstruction32::srli(srli {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    shamt: 4,
+                }),
+            ),
+            (
+                0x40455513,
+                ParsedInstruction32::srai(srai {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    shamt: 4,
+                }),
+            ),
             // Load instructions
-            (0x00A50503, ParsedInstruction32::lb (lb { rd: Register::x10, rs1: Register::x10, imm: 10 })),
-            (0x00A51503, ParsedInstruction32::lh (lh { rd: Register::x10, rs1: Register::x10, imm: 10 })),
-            (0x00A52503, ParsedInstruction32::lw (lw { rd: Register::x10, rs1: Register::x10, imm: 10 })),
-            (0x00A54503, ParsedInstruction32::lbu (lbu { rd: Register::x10, rs1: Register::x10, imm: 10 })),
-            (0x00A55503, ParsedInstruction32::lhu (lhu { rd: Register::x10, rs1: Register::x10, imm: 10 })),
-
+            (
+                0x00A50503,
+                ParsedInstruction32::lb(lb {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A51503,
+                ParsedInstruction32::lh(lh {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A52503,
+                ParsedInstruction32::lw(lw {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A54503,
+                ParsedInstruction32::lbu(lbu {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A55503,
+                ParsedInstruction32::lhu(lhu {
+                    rd: "x10".to_string(),
+                    rs1: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
             // S-type instructions
-            (0x00A50523, ParsedInstruction32::sb (sb { rs1: Register::x10, rs2: Register::x10, imm: 10 })),
-            (0x00A51523, ParsedInstruction32::sh (sh { rs1: Register::x10, rs2: Register::x10, imm: 10 })),
-            (0x00A52523, ParsedInstruction32::sw (sw { rs1: Register::x10, rs2: Register::x10, imm: 10 })),
-
+            (
+                0x00A50523,
+                ParsedInstruction32::sb(sb {
+                    rs1: "x10".to_string(),
+                    rs2: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A51523,
+                ParsedInstruction32::sh(sh {
+                    rs1: "x10".to_string(),
+                    rs2: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A52523,
+                ParsedInstruction32::sw(sw {
+                    rs1: "x10".to_string(),
+                    rs2: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
             // B-type instructions
-            (0x00a50563, ParsedInstruction32::beq (beq { rs1: Register::x10, rs2: Register::x10, imm: 10 })),
-            (0x00a51563, ParsedInstruction32::bne (bne { rs1: Register::x10, rs2: Register::x10, imm: 10 })),
-            (0x00a54563, ParsedInstruction32::blt (blt { rs1: Register::x10, rs2: Register::x10, imm: 10 })),
-            (0x00a55563, ParsedInstruction32::bge (bge { rs1: Register::x10, rs2: Register::x10, imm: 10 })),
-            (0x00a56563, ParsedInstruction32::bltu (bltu { rs1: Register::x10, rs2: Register::x10, imm: 10 })),
-            (0x00a57563, ParsedInstruction32::bgeu (bgeu { rs1: Register::x10, rs2: Register::x10, imm: 10 })),
-
+            (
+                0x00a50563,
+                ParsedInstruction32::beq(beq {
+                    rs1: "x10".to_string(),
+                    rs2: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00a51563,
+                ParsedInstruction32::bne(bne {
+                    rs1: "x10".to_string(),
+                    rs2: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00a54563,
+                ParsedInstruction32::blt(blt {
+                    rs1: "x10".to_string(),
+                    rs2: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00a55563,
+                ParsedInstruction32::bge(bge {
+                    rs1: "x10".to_string(),
+                    rs2: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00a56563,
+                ParsedInstruction32::bltu(bltu {
+                    rs1: "x10".to_string(),
+                    rs2: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00a57563,
+                ParsedInstruction32::bgeu(bgeu {
+                    rs1: "x10".to_string(),
+                    rs2: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
             // J-type instruction
-            (0x010000EF, ParsedInstruction32::jal (jal { rd: Register::x1, imm: 16 })),
-
+            (
+                0x010000EF,
+                ParsedInstruction32::jal(jal {
+                    rd: "x1".to_string(),
+                    imm: 16,
+                }),
+            ),
             // U-type instructions
-            (0x000100b7, ParsedInstruction32::lui (lui { rd: Register::x1, imm: 16<<12 })),
-            (0x00010097, ParsedInstruction32::auipc (auipc { rd: Register::x1, imm: 16<<12 })),
-
+            (
+                0x000100b7,
+                ParsedInstruction32::lui(lui {
+                    rd: "x1".to_string(),
+                    imm: 16 << 12,
+                }),
+            ),
+            (
+                0x00010097,
+                ParsedInstruction32::auipc(auipc {
+                    rd: "x1".to_string(),
+                    imm: 16 << 12,
+                }),
+            ),
             // I-type jump instruction
-            (0x00A500E7, ParsedInstruction32::jalr (jalr { rd: Register::x1, rs1: Register::x10, imm: 10 })),
+            (
+                0x00A500E7,
+                ParsedInstruction32::jalr(jalr {
+                    rd: "x1".to_string(),
+                    rs1: "x10".to_string(),
+                    imm: 10,
+                }),
+            ),
         ]
     }
 
     #[test]
     fn test_rv32i_instructions_le() {
         for (hex, expected) in get_rv32i_be_test_cases() {
-            let result = parse(&hex.to_le_bytes(), false);
+            let result = parse(&hex.to_le_bytes(), false, false);
             assert!(result.is_ok(), "Failed to parse instruction {:#010x}", hex);
             assert_eq!(result.unwrap(), expected);
         }
@@ -77,10 +323,9 @@ mod tests {
     #[test]
     fn test_rv32i_instructions_be() {
         for (hex, expected) in get_rv32i_be_test_cases() {
-            let result = parse(&hex.to_be_bytes(), true);
+            let result = parse(&hex.to_be_bytes(), true, false);
             assert!(result.is_ok(), "Failed to parse instruction {:#010x}", hex);
             assert_eq!(result.unwrap(), expected);
         }
     }
-
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,10 +1,9 @@
 #[cfg(test)]
 mod tests {
     use risc_v_disassembler::parse;
-    use risc_v_disassembler::Register;
     use risc_v_disassembler::{parsed_instructions::*, ParsedInstruction32};
 
-    /// Returns a vector of tuples containing (instruction hex, expected ParsedInstruction32) for RV32I instructions
+    /// Returns a vector of tuples containing (instruction hex, expected ParsedInstruction32) for RV32I instructions, using numbered registers
     fn get_rv32i_be_test_cases() -> Vec<(u32, ParsedInstruction32)> {
         vec![
             // R-type instructions
@@ -324,6 +323,331 @@ mod tests {
     fn test_rv32i_instructions_be() {
         for (hex, expected) in get_rv32i_be_test_cases() {
             let result = parse(&hex.to_be_bytes(), true, false);
+            assert!(result.is_ok(), "Failed to parse instruction {:#010x}", hex);
+            assert_eq!(result.unwrap(), expected);
+        }
+    }
+
+    /// Returns a vector of tuples containing (instruction hex, expected ParsedInstruction32) for RV32I instructions, using ABI registers
+    fn get_rv32i_be_test_cases_abi() -> Vec<(u32, ParsedInstruction32)> {
+        vec![
+            // R-type instructions
+            (
+                0x00B50533,
+                ParsedInstruction32::add(add {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    rs2: "a1".to_string(),
+                }),
+            ),
+            (
+                0x40B50533,
+                ParsedInstruction32::sub(sub {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    rs2: "a1".to_string(),
+                }),
+            ),
+            (
+                0x00B52533,
+                ParsedInstruction32::slt(slt {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    rs2: "a1".to_string(),
+                }),
+            ),
+            (
+                0x00B53533,
+                ParsedInstruction32::sltu(sltu {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    rs2: "a1".to_string(),
+                }),
+            ),
+            (
+                0x00B54533,
+                ParsedInstruction32::xor(xor {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    rs2: "a1".to_string(),
+                }),
+            ),
+            (
+                0x00B56533,
+                ParsedInstruction32::or(or {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    rs2: "a1".to_string(),
+                }),
+            ),
+            (
+                0x00B57533,
+                ParsedInstruction32::and(and {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    rs2: "a1".to_string(),
+                }),
+            ),
+            (
+                0x00B55533,
+                ParsedInstruction32::srl(srl {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    rs2: "a1".to_string(),
+                }),
+            ),
+            (
+                0x40B55533,
+                ParsedInstruction32::sra(sra {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    rs2: "a1".to_string(),
+                }),
+            ),
+            (
+                0x00B51533,
+                ParsedInstruction32::sll(sll {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    rs2: "a1".to_string(),
+                }),
+            ),
+            // I-type instructions
+            (
+                0x00A50513,
+                ParsedInstruction32::addi(addi {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A52513,
+                ParsedInstruction32::slti(slti {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A53513,
+                ParsedInstruction32::sltiu(sltiu {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A54513,
+                ParsedInstruction32::xori(xori {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A56513,
+                ParsedInstruction32::ori(ori {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A57513,
+                ParsedInstruction32::andi(andi {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00451513,
+                ParsedInstruction32::slli(slli {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    shamt: 4,
+                }),
+            ),
+            (
+                0x00455513,
+                ParsedInstruction32::srli(srli {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    shamt: 4,
+                }),
+            ),
+            (
+                0x40455513,
+                ParsedInstruction32::srai(srai {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    shamt: 4,
+                }),
+            ),
+            // Load instructions
+            (
+                0x00A50503,
+                ParsedInstruction32::lb(lb {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A51503,
+                ParsedInstruction32::lh(lh {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A52503,
+                ParsedInstruction32::lw(lw {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A54503,
+                ParsedInstruction32::lbu(lbu {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A55503,
+                ParsedInstruction32::lhu(lhu {
+                    rd: "a0".to_string(),
+                    rs1: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            // S-type instructions
+            (
+                0x00A50523,
+                ParsedInstruction32::sb(sb {
+                    rs1: "a0".to_string(),
+                    rs2: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A51523,
+                ParsedInstruction32::sh(sh {
+                    rs1: "a0".to_string(),
+                    rs2: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00A52523,
+                ParsedInstruction32::sw(sw {
+                    rs1: "a0".to_string(),
+                    rs2: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            // B-type instructions
+            (
+                0x00a50563,
+                ParsedInstruction32::beq(beq {
+                    rs1: "a0".to_string(),
+                    rs2: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00a51563,
+                ParsedInstruction32::bne(bne {
+                    rs1: "a0".to_string(),
+                    rs2: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00a54563,
+                ParsedInstruction32::blt(blt {
+                    rs1: "a0".to_string(),
+                    rs2: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00a55563,
+                ParsedInstruction32::bge(bge {
+                    rs1: "a0".to_string(),
+                    rs2: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00a56563,
+                ParsedInstruction32::bltu(bltu {
+                    rs1: "a0".to_string(),
+                    rs2: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            (
+                0x00a57563,
+                ParsedInstruction32::bgeu(bgeu {
+                    rs1: "a0".to_string(),
+                    rs2: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+            // J-type instruction
+            (
+                0x010000EF,
+                ParsedInstruction32::jal(jal {
+                    rd: "ra".to_string(),
+                    imm: 16,
+                }),
+            ),
+            // U-type instructions
+            (
+                0x000100b7,
+                ParsedInstruction32::lui(lui {
+                    rd: "ra".to_string(),
+                    imm: 16 << 12,
+                }),
+            ),
+            (
+                0x00010097,
+                ParsedInstruction32::auipc(auipc {
+                    rd: "ra".to_string(),
+                    imm: 16 << 12,
+                }),
+            ),
+            // I-type jump instruction
+            (
+                0x00A500E7,
+                ParsedInstruction32::jalr(jalr {
+                    rd: "ra".to_string(),
+                    rs1: "a0".to_string(),
+                    imm: 10,
+                }),
+            ),
+        ]
+    }
+
+    #[test]
+    fn test_rv32i_instructions_le_abi() {
+        for (hex, expected) in get_rv32i_be_test_cases_abi() {
+            let result = parse(&hex.to_le_bytes(), false, true);
+            assert!(result.is_ok(), "Failed to parse instruction {:#010x}", hex);
+            assert_eq!(result.unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn test_rv32i_instructions_be_abi() {
+        for (hex, expected) in get_rv32i_be_test_cases_abi() {
+            let result = parse(&hex.to_be_bytes(), true, true);
             assert!(result.is_ok(), "Failed to parse instruction {:#010x}", hex);
             assert_eq!(result.unwrap(), expected);
         }


### PR DESCRIPTION
The `ParsedInstruction` struct now uses strings instead of a Register struct, the parsers now take a generic bound to the (new) trait `Register`, and the main parser (called by client programs) takes a boolean `use_abi_register_names`.